### PR TITLE
correcting names for docker hub location for the image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TARGET ?= darwin
 ARCH ?= amd64
-DOCKER_REPO=telia-oss/github-pr-resource
+DOCKER_REPO=teliaoss/github-pr-resource
 SRC=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 default: test

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ resource_types:
 - name: pull-request
   type: docker-image
   source:
-    repository: telia-oss/github-pr-resource
+    repository: teliaoss/github-pr-resource
 
 resources:
 - name: pull-request


### PR DESCRIPTION
When the repo was renamed, the new name for the docker image is `teliaoss/github-pr-resource` but there were a couple of references to it as `telia-oss/github-pr-resource` which doesn't exist.

The purpose of this PR is to correct that.