### PR TITLE
Make disable_ci_skip a boolean instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Inspired by [the original](https://github.com/jtarchie/github-pullrequest-resour
 | `v4_endpoint`     | No       | `https://api.github.com/graphql` | Endpoint to use for the V4 Github API (Graphql).                                                                     |
 | `paths`           | No       | `terraform/**/*.tf`              | Only produce new versions if the PR includes changes to files that match one or more glob pattern.                   |
 | `ignore_paths`    | No       | `.ci/*`                          | Inverse of the above. Pattern syntax is documented in [filepath.Match](https://golang.org/pkg/path/filepath/#Match). |
-| `disable_ci_skip` | No       | `true` (string)                  | Disable ability to skip builds with `[ci skip]` and `[skip ci]` in commit message or pull request title.             |
+| `disable_ci_skip` | No       | `true`                           | Disable ability to skip builds with `[ci skip]` and `[skip ci]` in commit message or pull request title.             |
 
 Note: If `v3_endpoint` is set, `v4_endpoint` must also be set (and the other way around).
 

--- a/check.go
+++ b/check.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 )
 
 // Check (business logic)
@@ -16,13 +15,8 @@ func Check(request CheckRequest, manager Github) (CheckResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get last commits: %s", err)
 	}
-	var disableSkipCI bool
-	if request.Source.DisableCISkip != "" {
-		disableSkipCI, err = strconv.ParseBool(request.Source.DisableCISkip)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse disable_ci_skip: %s", err)
-		}
-	}
+
+	disableSkipCI := request.Source.DisableCISkip
 
 Loop:
 	for _, p := range pulls {

--- a/check_test.go
+++ b/check_test.go
@@ -112,7 +112,7 @@ func TestCheck(t *testing.T) {
 			source: resource.Source{
 				Repository:    "itsdalmo/test-repository",
 				AccessToken:   "oauthtoken",
-				DisableCISkip: "true",
+				DisableCISkip: true,
 			},
 			version:      resource.NewVersion(testPullRequests[1]),
 			pullRequests: testPullRequests,

--- a/models.go
+++ b/models.go
@@ -16,7 +16,7 @@ type Source struct {
 	V4Endpoint    string   `json:"v4_endpoint"`
 	Paths         []string `json:"path"`
 	IgnorePaths   []string `json:"ignore_path"`
-	DisableCISkip string   `json:"disable_ci_skip"`
+	DisableCISkip bool     `json:"disable_ci_skip"`
 }
 
 // Validate the source configuration.


### PR DESCRIPTION
Ref #37 - for consistency we should use true boolean values wherever possible. I'm not sure why I opted for boolean parseable string to begin with 🤷‍♂️ 