### PR TITLE
Add contextual information to rev-parse errors

### DIFF
--- a/git.go
+++ b/git.go
@@ -117,7 +117,7 @@ func (g *GitClient) RevParse(branch string) (string, error) {
 	cmd.Dir = g.Directory
 	sha, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("rev-parse '%s' failed: %s: %s", branch, err, string(sha))
 	}
 	return strings.TrimSpace(string(sha)), nil
 }


### PR DESCRIPTION
Ref https://github.com/telia-oss/github-pr-resource/issues/35#issuecomment-424326762 - we need to add more contextual information to the error message so that its possible to debug failing `get` operations.

This PR should make it so that:
```
get failed: exit status 128
```

Becomes:
```
get failed: rev-parse 'somebranch' failed: exit status 128: fatal: Needed a single revision
```