### PR TITLE
Use git clone instead of git pull to support non-master bases

### DIFF
--- a/git.go
+++ b/git.go
@@ -13,12 +13,11 @@ import (
 // Git interface for testing purposes.
 //go:generate mockgen -destination=mocks/mock_git.go -package=mocks github.com/telia-oss/github-pr-resource Git
 type Git interface {
-	Clone(string, string) error
-	Config() error
-	Fetch(string, int) error
-	Checkout(string) error
-	Merge(string) error
+	Init(string) error
+	Pull(string, string) error
 	RevParse(string) (string, error)
+	Fetch(string, int) error
+	Merge(string) error
 }
 
 // NewGitClient ...
@@ -45,13 +44,30 @@ func (g *GitClient) command(name string, arg ...string) *exec.Cmd {
 	return cmd
 }
 
-// Clone ...
-func (g *GitClient) Clone(uri, branch string) error {
+// Init ...
+func (g *GitClient) Init(branch string) error {
+	if err := g.command("git", "init").Run(); err != nil {
+		return fmt.Errorf("init failed: %s", err)
+	}
+	if err := g.command("git", "checkout", "-b", branch).Run(); err != nil {
+		return fmt.Errorf("checkout to '%s' failed: %s", branch, err)
+	}
+	if err := g.command("git", "config", "user.name", "concourse-ci").Run(); err != nil {
+		return fmt.Errorf("failed to configure git user: %s", err)
+	}
+	if err := g.command("git", "config", "user.email", "concourse@local").Run(); err != nil {
+		return fmt.Errorf("failed to configure git email: %s", err)
+	}
+	return nil
+}
+
+// Pull ...
+func (g *GitClient) Pull(uri, branch string) error {
 	endpoint, err := g.Endpoint(uri)
 	if err != nil {
 		return err
 	}
-	cmd := g.command("git", "clone", "-b", branch, "--single-branch", endpoint+".git", ".")
+	cmd := g.command("git", "pull", endpoint+".git", branch)
 
 	// Discard output to have zero chance of logging the access token.
 	cmd.Stdout = ioutil.Discard
@@ -63,15 +79,15 @@ func (g *GitClient) Clone(uri, branch string) error {
 	return nil
 }
 
-// Config ...
-func (g *GitClient) Config() error {
-	if err := g.command("git", "config", "user.name", "concourse-ci").Run(); err != nil {
-		return fmt.Errorf("failed to configure git user: %s", err)
+// RevParse retrieves the SHA of the given branch.
+func (g *GitClient) RevParse(branch string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--verify", branch)
+	cmd.Dir = g.Directory
+	sha, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("rev-parse '%s' failed: %s: %s", branch, err, string(sha))
 	}
-	if err := g.command("git", "config", "user.email", "concourse@local").Run(); err != nil {
-		return fmt.Errorf("failed to configure git email: %s", err)
-	}
-	return nil
+	return strings.TrimSpace(string(sha)), nil
 }
 
 // Fetch ...
@@ -92,31 +108,12 @@ func (g *GitClient) Fetch(uri string, prNumber int) error {
 	return nil
 }
 
-// Checkout ...
-func (g *GitClient) Checkout(name string) error {
-	if err := g.command("git", "checkout", "-b", name).Run(); err != nil {
-		return fmt.Errorf("failed to checkout new branch: %s", err)
-	}
-	return nil
-}
-
 // Merge ...
 func (g *GitClient) Merge(sha string) error {
 	if err := g.command("git", "merge", sha, "--no-stat").Run(); err != nil {
 		return fmt.Errorf("merge failed: %s", err)
 	}
 	return nil
-}
-
-// RevParse retrieves the SHA of the given branch.
-func (g *GitClient) RevParse(branch string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--verify", branch)
-	cmd.Dir = g.Directory
-	sha, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("rev-parse '%s' failed: %s: %s", branch, err, string(sha))
-	}
-	return strings.TrimSpace(string(sha)), nil
 }
 
 // Endpoint takes an uri and produces an endpoint with the login information baked in.

--- a/git.go
+++ b/git.go
@@ -14,7 +14,7 @@ import (
 //go:generate mockgen -destination=mocks/mock_git.go -package=mocks github.com/telia-oss/github-pr-resource Git
 type Git interface {
 	Init() error
-	Pull(string) error
+	Pull(string, string) error
 	Fetch(string, int) error
 	Checkout(string) error
 	Merge(string) error
@@ -60,12 +60,12 @@ func (g *GitClient) Init() error {
 }
 
 // Pull ...
-func (g *GitClient) Pull(uri string) error {
+func (g *GitClient) Pull(uri, branch string) error {
 	endpoint, err := g.Endpoint(uri)
 	if err != nil {
 		return err
 	}
-	cmd := g.command("git", "pull", endpoint+".git")
+	cmd := g.command("git", "pull", endpoint+".git", branch)
 
 	// Discard output to have zero chance of logging the access token.
 	cmd.Stdout = ioutil.Discard

--- a/git.go
+++ b/git.go
@@ -13,8 +13,8 @@ import (
 // Git interface for testing purposes.
 //go:generate mockgen -destination=mocks/mock_git.go -package=mocks github.com/telia-oss/github-pr-resource Git
 type Git interface {
-	Config() error
 	Clone(string, string) error
+	Config() error
 	Fetch(string, int) error
 	Checkout(string) error
 	Merge(string) error
@@ -45,17 +45,6 @@ func (g *GitClient) command(name string, arg ...string) *exec.Cmd {
 	return cmd
 }
 
-// Config ...
-func (g *GitClient) Config() error {
-	if err := g.command("git", "config", "user.name", "concourse-ci").Run(); err != nil {
-		return fmt.Errorf("failed to configure git user: %s", err)
-	}
-	if err := g.command("git", "config", "user.email", "concourse@local").Run(); err != nil {
-		return fmt.Errorf("failed to configure git email: %s", err)
-	}
-	return nil
-}
-
 // Clone ...
 func (g *GitClient) Clone(uri, branch string) error {
 	endpoint, err := g.Endpoint(uri)
@@ -70,6 +59,17 @@ func (g *GitClient) Clone(uri, branch string) error {
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("clone failed: %s", err)
+	}
+	return nil
+}
+
+// Config ...
+func (g *GitClient) Config() error {
+	if err := g.command("git", "config", "user.name", "concourse-ci").Run(); err != nil {
+		return fmt.Errorf("failed to configure git user: %s", err)
+	}
+	if err := g.command("git", "config", "user.email", "concourse@local").Run(); err != nil {
+		return fmt.Errorf("failed to configure git email: %s", err)
 	}
 	return nil
 }

--- a/git.go
+++ b/git.go
@@ -62,7 +62,7 @@ func (g *GitClient) Clone(uri, branch string) error {
 	if err != nil {
 		return err
 	}
-	cmd := g.command("git", "clone", "-b", branch, endpoint+".git", ".")
+	cmd := g.command("git", "clone", "-b", branch, "--single-branch", endpoint+".git", ".")
 
 	// Discard output to have zero chance of logging the access token.
 	cmd.Stdout = ioutil.Discard

--- a/in.go
+++ b/in.go
@@ -20,23 +20,22 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 		return nil, fmt.Errorf("failed to retrieve pull request: %s", err)
 	}
 
-	// Clone the repository and fetch the PR
-	if err := git.Clone(pull.Repository.URL, pull.BaseRefName); err != nil {
+	// Initialize and pull the base for the PR
+	if err := git.Init(pull.BaseRefName); err != nil {
 		return nil, err
 	}
-	if err := git.Config(); err != nil {
-		return nil, err
-	}
-	if err := git.Fetch(pull.Repository.URL, pull.Number); err != nil {
+	if err := git.Pull(pull.Repository.URL, pull.BaseRefName); err != nil {
 		return nil, err
 	}
 
-	// Create a branch from the base ref and merge PR into it
+	// Get the last commit SHA in base for the metadata
 	baseSHA, err := git.RevParse(pull.BaseRefName)
 	if err != nil {
 		return nil, err
 	}
-	if err := git.Checkout(baseSHA); err != nil {
+
+	// Fetch the PR and merge the specified commit into the base
+	if err := git.Fetch(pull.Repository.URL, pull.Number); err != nil {
 		return nil, err
 	}
 	if err := git.Merge(pull.Tip.OID); err != nil {

--- a/in.go
+++ b/in.go
@@ -21,10 +21,10 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 	}
 
 	// Clone the repository and fetch the PR
-	if err := git.Init(); err != nil {
+	if err := git.Clone(pull.Repository.URL, pull.BaseRefName); err != nil {
 		return nil, err
 	}
-	if err := git.Pull(pull.Repository.URL, pull.BaseRefName); err != nil {
+	if err := git.Config(); err != nil {
 		return nil, err
 	}
 	if err := git.Fetch(pull.Repository.URL, pull.Number); err != nil {

--- a/in.go
+++ b/in.go
@@ -24,7 +24,7 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 	if err := git.Init(); err != nil {
 		return nil, err
 	}
-	if err := git.Pull(pull.Repository.URL); err != nil {
+	if err := git.Pull(pull.Repository.URL, pull.BaseRefName); err != nil {
 		return nil, err
 	}
 	if err := git.Fetch(pull.Repository.URL, pull.Number); err != nil {

--- a/in_test.go
+++ b/in_test.go
@@ -56,7 +56,7 @@ func TestGet(t *testing.T) {
 			git := mocks.NewMockGit(ctrl)
 			gomock.InOrder(
 				git.EXPECT().Init().Times(1).Return(nil),
-				git.EXPECT().Pull(tc.pullRequest.Repository.URL).Times(1).Return(nil),
+				git.EXPECT().Pull(tc.pullRequest.Repository.URL, tc.pullRequest.BaseRefName).Times(1).Return(nil),
 				git.EXPECT().Fetch(tc.pullRequest.Repository.URL, tc.pullRequest.Number).Times(1).Return(nil),
 				git.EXPECT().RevParse(tc.pullRequest.BaseRefName).Times(1).Return("sha", nil),
 				git.EXPECT().Checkout("sha").Times(1).Return(nil),

--- a/in_test.go
+++ b/in_test.go
@@ -55,8 +55,8 @@ func TestGet(t *testing.T) {
 
 			git := mocks.NewMockGit(ctrl)
 			gomock.InOrder(
-				git.EXPECT().Init().Times(1).Return(nil),
-				git.EXPECT().Pull(tc.pullRequest.Repository.URL, tc.pullRequest.BaseRefName).Times(1).Return(nil),
+				git.EXPECT().Clone(tc.pullRequest.Repository.URL, tc.pullRequest.BaseRefName).Times(1).Return(nil),
+				git.EXPECT().Config().Times(1).Return(nil),
 				git.EXPECT().Fetch(tc.pullRequest.Repository.URL, tc.pullRequest.Number).Times(1).Return(nil),
 				git.EXPECT().RevParse(tc.pullRequest.BaseRefName).Times(1).Return("sha", nil),
 				git.EXPECT().Checkout("sha").Times(1).Return(nil),

--- a/in_test.go
+++ b/in_test.go
@@ -55,11 +55,10 @@ func TestGet(t *testing.T) {
 
 			git := mocks.NewMockGit(ctrl)
 			gomock.InOrder(
-				git.EXPECT().Clone(tc.pullRequest.Repository.URL, tc.pullRequest.BaseRefName).Times(1).Return(nil),
-				git.EXPECT().Config().Times(1).Return(nil),
-				git.EXPECT().Fetch(tc.pullRequest.Repository.URL, tc.pullRequest.Number).Times(1).Return(nil),
+				git.EXPECT().Init(tc.pullRequest.BaseRefName).Times(1).Return(nil),
+				git.EXPECT().Pull(tc.pullRequest.Repository.URL, tc.pullRequest.BaseRefName).Times(1).Return(nil),
 				git.EXPECT().RevParse(tc.pullRequest.BaseRefName).Times(1).Return("sha", nil),
-				git.EXPECT().Checkout("sha").Times(1).Return(nil),
+				git.EXPECT().Fetch(tc.pullRequest.Repository.URL, tc.pullRequest.Number).Times(1).Return(nil),
 				git.EXPECT().Merge(tc.pullRequest.Tip.OID).Times(1).Return(nil),
 			)
 

--- a/mocks/mock_git.go
+++ b/mocks/mock_git.go
@@ -44,6 +44,30 @@ func (mr *MockGitMockRecorder) Checkout(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Checkout", reflect.TypeOf((*MockGit)(nil).Checkout), arg0)
 }
 
+// Clone mocks base method
+func (m *MockGit) Clone(arg0, arg1 string) error {
+	ret := m.ctrl.Call(m, "Clone", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Clone indicates an expected call of Clone
+func (mr *MockGitMockRecorder) Clone(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockGit)(nil).Clone), arg0, arg1)
+}
+
+// Config mocks base method
+func (m *MockGit) Config() error {
+	ret := m.ctrl.Call(m, "Config")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Config indicates an expected call of Config
+func (mr *MockGitMockRecorder) Config() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockGit)(nil).Config))
+}
+
 // Fetch mocks base method
 func (m *MockGit) Fetch(arg0 string, arg1 int) error {
 	ret := m.ctrl.Call(m, "Fetch", arg0, arg1)
@@ -56,18 +80,6 @@ func (mr *MockGitMockRecorder) Fetch(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockGit)(nil).Fetch), arg0, arg1)
 }
 
-// Init mocks base method
-func (m *MockGit) Init() error {
-	ret := m.ctrl.Call(m, "Init")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Init indicates an expected call of Init
-func (mr *MockGitMockRecorder) Init() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockGit)(nil).Init))
-}
-
 // Merge mocks base method
 func (m *MockGit) Merge(arg0 string) error {
 	ret := m.ctrl.Call(m, "Merge", arg0)
@@ -78,18 +90,6 @@ func (m *MockGit) Merge(arg0 string) error {
 // Merge indicates an expected call of Merge
 func (mr *MockGitMockRecorder) Merge(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Merge", reflect.TypeOf((*MockGit)(nil).Merge), arg0)
-}
-
-// Pull mocks base method
-func (m *MockGit) Pull(arg0, arg1 string) error {
-	ret := m.ctrl.Call(m, "Pull", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Pull indicates an expected call of Pull
-func (mr *MockGitMockRecorder) Pull(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pull", reflect.TypeOf((*MockGit)(nil).Pull), arg0, arg1)
 }
 
 // RevParse mocks base method

--- a/mocks/mock_git.go
+++ b/mocks/mock_git.go
@@ -44,30 +44,6 @@ func (mr *MockGitMockRecorder) Checkout(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Checkout", reflect.TypeOf((*MockGit)(nil).Checkout), arg0)
 }
 
-// Clone mocks base method
-func (m *MockGit) Clone(arg0, arg1 string) error {
-	ret := m.ctrl.Call(m, "Clone", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Clone indicates an expected call of Clone
-func (mr *MockGitMockRecorder) Clone(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockGit)(nil).Clone), arg0, arg1)
-}
-
-// Config mocks base method
-func (m *MockGit) Config() error {
-	ret := m.ctrl.Call(m, "Config")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Config indicates an expected call of Config
-func (mr *MockGitMockRecorder) Config() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockGit)(nil).Config))
-}
-
 // Fetch mocks base method
 func (m *MockGit) Fetch(arg0 string, arg1 int) error {
 	ret := m.ctrl.Call(m, "Fetch", arg0, arg1)
@@ -80,6 +56,18 @@ func (mr *MockGitMockRecorder) Fetch(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockGit)(nil).Fetch), arg0, arg1)
 }
 
+// Init mocks base method
+func (m *MockGit) Init(arg0 string) error {
+	ret := m.ctrl.Call(m, "Init", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Init indicates an expected call of Init
+func (mr *MockGitMockRecorder) Init(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockGit)(nil).Init), arg0)
+}
+
 // Merge mocks base method
 func (m *MockGit) Merge(arg0 string) error {
 	ret := m.ctrl.Call(m, "Merge", arg0)
@@ -90,6 +78,18 @@ func (m *MockGit) Merge(arg0 string) error {
 // Merge indicates an expected call of Merge
 func (mr *MockGitMockRecorder) Merge(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Merge", reflect.TypeOf((*MockGit)(nil).Merge), arg0)
+}
+
+// Pull mocks base method
+func (m *MockGit) Pull(arg0, arg1 string) error {
+	ret := m.ctrl.Call(m, "Pull", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Pull indicates an expected call of Pull
+func (mr *MockGitMockRecorder) Pull(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pull", reflect.TypeOf((*MockGit)(nil).Pull), arg0, arg1)
 }
 
 // RevParse mocks base method

--- a/mocks/mock_git.go
+++ b/mocks/mock_git.go
@@ -81,15 +81,15 @@ func (mr *MockGitMockRecorder) Merge(arg0 interface{}) *gomock.Call {
 }
 
 // Pull mocks base method
-func (m *MockGit) Pull(arg0 string) error {
-	ret := m.ctrl.Call(m, "Pull", arg0)
+func (m *MockGit) Pull(arg0, arg1 string) error {
+	ret := m.ctrl.Call(m, "Pull", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Pull indicates an expected call of Pull
-func (mr *MockGitMockRecorder) Pull(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pull", reflect.TypeOf((*MockGit)(nil).Pull), arg0)
+func (mr *MockGitMockRecorder) Pull(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pull", reflect.TypeOf((*MockGit)(nil).Pull), arg0, arg1)
 }
 
 // RevParse mocks base method

--- a/out_test.go
+++ b/out_test.go
@@ -98,8 +98,8 @@ func TestPut(t *testing.T) {
 
 			git := mocks.NewMockGit(ctrl)
 			gomock.InOrder(
-				git.EXPECT().Init().Times(1).Return(nil),
-				git.EXPECT().Pull(tc.pullRequest.Repository.URL, tc.pullRequest.BaseRefName).Times(1).Return(nil),
+				git.EXPECT().Clone(tc.pullRequest.Repository.URL, tc.pullRequest.BaseRefName).Times(1).Return(nil),
+				git.EXPECT().Config().Times(1).Return(nil),
 				git.EXPECT().Fetch(tc.pullRequest.Repository.URL, tc.pullRequest.Number).Times(1).Return(nil),
 				git.EXPECT().RevParse(tc.pullRequest.BaseRefName).Times(1).Return("sha", nil),
 				git.EXPECT().Checkout("sha").Times(1).Return(nil),

--- a/out_test.go
+++ b/out_test.go
@@ -99,7 +99,7 @@ func TestPut(t *testing.T) {
 			git := mocks.NewMockGit(ctrl)
 			gomock.InOrder(
 				git.EXPECT().Init().Times(1).Return(nil),
-				git.EXPECT().Pull(tc.pullRequest.Repository.URL).Times(1).Return(nil),
+				git.EXPECT().Pull(tc.pullRequest.Repository.URL, tc.pullRequest.BaseRefName).Times(1).Return(nil),
 				git.EXPECT().Fetch(tc.pullRequest.Repository.URL, tc.pullRequest.Number).Times(1).Return(nil),
 				git.EXPECT().RevParse(tc.pullRequest.BaseRefName).Times(1).Return("sha", nil),
 				git.EXPECT().Checkout("sha").Times(1).Return(nil),

--- a/out_test.go
+++ b/out_test.go
@@ -98,11 +98,10 @@ func TestPut(t *testing.T) {
 
 			git := mocks.NewMockGit(ctrl)
 			gomock.InOrder(
-				git.EXPECT().Clone(tc.pullRequest.Repository.URL, tc.pullRequest.BaseRefName).Times(1).Return(nil),
-				git.EXPECT().Config().Times(1).Return(nil),
-				git.EXPECT().Fetch(tc.pullRequest.Repository.URL, tc.pullRequest.Number).Times(1).Return(nil),
+				git.EXPECT().Init(tc.pullRequest.BaseRefName).Times(1).Return(nil),
+				git.EXPECT().Pull(tc.pullRequest.Repository.URL, tc.pullRequest.BaseRefName).Times(1).Return(nil),
 				git.EXPECT().RevParse(tc.pullRequest.BaseRefName).Times(1).Return("sha", nil),
-				git.EXPECT().Checkout("sha").Times(1).Return(nil),
+				git.EXPECT().Fetch(tc.pullRequest.Repository.URL, tc.pullRequest.Number).Times(1).Return(nil),
 				git.EXPECT().Merge(tc.pullRequest.Tip.OID).Times(1).Return(nil),
 			)
 


### PR DESCRIPTION
Ref #35 - Using `git clone` and specifying the base branch should ensure that the target branch for the PR is available locally when we run `rev-parse`. In effect, I don't think the previous implementation has ever supported non-master bases.

I've added an E2E test which reproduces the reported error, and does not complain when run against the code in this PR. So hopefully it is fixed 🤞 