### PR TITLE
Add skip ssl param

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,16 @@ Inspired by [the original](https://github.com/jtarchie/github-pullrequest-resour
 
 ## Source Configuration
 
-|     Parameter     | Required |             Example              |                                                     Description                                                      |
-| ----------------- | -------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `repository`      | Yes      | `itsdalmo/test-repository`       | The repository to target.                                                                                            |
-| `access_token`    | Yes      |                                  | A Github Access Token with repository access (required for setting status on commits).                               |
-| `v3_endpoint`     | No       | `https://api.github.com`         | Endpoint to use for the V3 Github API (Restful).                                                                     |
-| `v4_endpoint`     | No       | `https://api.github.com/graphql` | Endpoint to use for the V4 Github API (Graphql).                                                                     |
-| `paths`           | No       | `terraform/*/*.tf`               | Only produce new versions if the PR includes changes to files that match one or more glob pattern.                   |
-| `ignore_paths`    | No       | `.ci/*`                          | Inverse of the above. Pattern syntax is documented in [filepath.Match](https://golang.org/pkg/path/filepath/#Match). |
-| `disable_ci_skip` | No       | `true`                           | Disable ability to skip builds with `[ci skip]` and `[skip ci]` in commit message or pull request title.             |
+| Parameter               | Required | Example                          | Description                                                                                                          |
+|-------------------------|----------|----------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `repository`            | Yes      | `itsdalmo/test-repository`       | The repository to target.                                                                                            |
+| `access_token`          | Yes      |                                  | A Github Access Token with repository access (required for setting status on commits).                               |
+| `v3_endpoint`           | No       | `https://api.github.com`         | Endpoint to use for the V3 Github API (Restful).                                                                     |
+| `v4_endpoint`           | No       | `https://api.github.com/graphql` | Endpoint to use for the V4 Github API (Graphql).                                                                     |
+| `paths`                 | No       | `terraform/*/*.tf`               | Only produce new versions if the PR includes changes to files that match one or more glob pattern.                   |
+| `ignore_paths`          | No       | `.ci/*`                          | Inverse of the above. Pattern syntax is documented in [filepath.Match](https://golang.org/pkg/path/filepath/#Match). |
+| `disable_ci_skip`       | No       | `true`                           | Disable ability to skip builds with `[ci skip]` and `[skip ci]` in commit message or pull request title.             |
+| `skip_ssl_verification` | No       | `true`                           | Disable SSL/TLS certificate validation on git and API clients. Use with care!                                        |
 
 Note: If `v3_endpoint` is set, `v4_endpoint` must also be set (and the other way around).
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -158,7 +158,7 @@ func TestGetAndPutE2E(t *testing.T) {
 			metadataString: `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
 		},
 		{
-			description: "get works with non-master bases (and disabled ci skip)",
+			description: "get works with non-master bases",
 			source: resource.Source{
 				Repository:  "itsdalmo/test-repository",
 				V3Endpoint:  "https://api.github.com/",

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -175,6 +175,25 @@ func TestGetAndPutE2E(t *testing.T) {
 			versionString:  `{"pr":"6","commit":"ac771f3b69cbd63b22bbda553f827ab36150c640","committed":"0001-01-01T00:00:00Z"}`,
 			metadataString: `[{"name":"pr","value":"6"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/6"},{"name":"head_sha","value":"ac771f3b69cbd63b22bbda553f827ab36150c640"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"[skip ci] Add a PR with a non-master base"},{"name":"author","value":"itsdalmo"}]`,
 		},
+		{
+			description: "get works when ssl verification is disabled",
+			source: resource.Source{
+				Repository:          "itsdalmo/test-repository",
+				V3Endpoint:          "https://api.github.com/",
+				V4Endpoint:          "https://api.github.com/graphql",
+				AccessToken:         os.Getenv("GITHUB_ACCESS_TOKEN"),
+				SkipSSLVerification: true,
+			},
+			version: resource.Version{
+				PR:            targetPullRequestID,
+				Commit:        targetCommitID,
+				CommittedDate: time.Time{},
+			},
+			getParameters:  resource.GetParameters{},
+			putParameters:  resource.PutParameters{},
+			versionString:  `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
+			metadataString: `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/git.go
+++ b/git.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/url"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -22,6 +23,9 @@ type Git interface {
 
 // NewGitClient ...
 func NewGitClient(source *Source, dir string, output io.Writer) (*GitClient, error) {
+	if source.SkipSSLVerification {
+		os.Setenv("GIT_SSL_NO_VERIFY", "true")
+	}
 	return &GitClient{
 		AccessToken: source.AccessToken,
 		Directory:   dir,

--- a/github.go
+++ b/github.go
@@ -2,8 +2,10 @@ package resource
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -39,7 +41,24 @@ func NewGithubClient(s *Source) (*GithubClient, error) {
 		return nil, err
 	}
 
-	client := oauth2.NewClient(context.TODO(), oauth2.StaticTokenSource(
+	if s.SkipSSLVerification {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	// Skip SSL verification for self-signed certificates
+	// source: https://github.com/google/go-github/pull/598#issuecomment-333039238
+	var ctx context.Context
+	if s.SkipSSLVerification {
+		insecureClient := &http.Client{Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		}
+		ctx = context.WithValue(context.TODO(), oauth2.HTTPClient, insecureClient)
+	} else {
+		ctx = context.TODO()
+	}
+
+	client := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: s.AccessToken},
 	))
 

--- a/github.go
+++ b/github.go
@@ -41,10 +41,6 @@ func NewGithubClient(s *Source) (*GithubClient, error) {
 		return nil, err
 	}
 
-	if s.SkipSSLVerification {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
-
 	// Skip SSL verification for self-signed certificates
 	// source: https://github.com/google/go-github/pull/598#issuecomment-333039238
 	var ctx context.Context

--- a/mocks/mock_git.go
+++ b/mocks/mock_git.go
@@ -32,18 +32,6 @@ func (m *MockGit) EXPECT() *MockGitMockRecorder {
 	return m.recorder
 }
 
-// Checkout mocks base method
-func (m *MockGit) Checkout(arg0 string) error {
-	ret := m.ctrl.Call(m, "Checkout", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Checkout indicates an expected call of Checkout
-func (mr *MockGitMockRecorder) Checkout(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Checkout", reflect.TypeOf((*MockGit)(nil).Checkout), arg0)
-}
-
 // Fetch mocks base method
 func (m *MockGit) Fetch(arg0 string, arg1 int) error {
 	ret := m.ctrl.Call(m, "Fetch", arg0, arg1)

--- a/models.go
+++ b/models.go
@@ -10,13 +10,14 @@ import (
 
 // Source represents the configuration for the resource.
 type Source struct {
-	Repository    string   `json:"repository"`
-	AccessToken   string   `json:"access_token"`
-	V3Endpoint    string   `json:"v3_endpoint"`
-	V4Endpoint    string   `json:"v4_endpoint"`
-	Paths         []string `json:"path"`
-	IgnorePaths   []string `json:"ignore_path"`
-	DisableCISkip bool     `json:"disable_ci_skip"`
+	Repository          string   `json:"repository"`
+	AccessToken         string   `json:"access_token"`
+	V3Endpoint          string   `json:"v3_endpoint"`
+	V4Endpoint          string   `json:"v4_endpoint"`
+	Paths               []string `json:"path"`
+	IgnorePaths         []string `json:"ignore_path"`
+	DisableCISkip       bool     `json:"disable_ci_skip"`
+	SkipSSLVerification bool     `json:"skip_ssl_verification"`
 }
 
 // Validate the source configuration.


### PR DESCRIPTION
Ref #42 - this PR adds `skip_ssl_verification` to the source configuration. I have not verified that this actually works, other than that it does not break regular functionality - will need someone to test this on their own GHE with an untrusted certificate.