### PR TITLE
Fix mismatch between documented and implemented paths/ignore paths

### DIFF
--- a/models.go
+++ b/models.go
@@ -14,8 +14,8 @@ type Source struct {
 	AccessToken   string   `json:"access_token"`
 	V3Endpoint    string   `json:"v3_endpoint"`
 	V4Endpoint    string   `json:"v4_endpoint"`
-	Paths         []string `json:"path"`
-	IgnorePaths   []string `json:"ignore_path"`
+	Paths         []string `json:"paths"`
+	IgnorePaths   []string `json:"ignore_paths"`
 	DisableCISkip bool     `json:"disable_ci_skip"`
 }
 


### PR DESCRIPTION
Closes #44 - i.e., it is a bug fix which will be a breaking change for anyone who might have figured out that `paths` and `ignore_paths` (as documented) did nothing, while `path` and `ignore_path` should have worked 😂 