### PR TITLE
Feature request: disable_forks parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `ignore_paths`          | No       | `.ci/`                          | Inverse of the above. Pattern syntax is documented in [filepath.Match](https://golang.org/pkg/path/filepath/#Match), or a path prefix can be specified (e.g. `.ci/` will match everything in the `.ci` directory).                                                                                                                                                                        |
 | `disable_ci_skip`       | No       | `true`                           | Disable ability to skip builds with `[ci skip]` and `[skip ci]` in commit message or pull request title.                                                                                                                                                                                   |
 | `skip_ssl_verification` | No       | `true`                           | Disable SSL/TLS certificate validation on git and API clients. Use with care!                                                                                                                                                                                                              |
+| `disable_forks`         | No       | `true`                           | Disable triggering of the resource if the pull request's fork repository is different to the configured repository.                                                                                                                                                                        |
 
 Note: If `v3_endpoint` is set, `v4_endpoint` must also be set (and the other way around).
 
@@ -197,7 +198,6 @@ If you are coming from [jtarchie/github-pullrequest-resource][original-resource]
 #### Parameters that did not make it:
 - `src`:
   - `base`: 
-  - `disable_forks`
   - `require_review_approval`
   - `authorship_restriction`
   - `label`

--- a/check.go
+++ b/check.go
@@ -34,6 +34,10 @@ Loop:
 			continue
 		}
 
+		if request.Source.DisableForks && p.IsCrossRepository {
+			continue
+		}
+
 		// Fetch files once if paths/ignore_paths are specified.
 		var files []string
 

--- a/check_test.go
+++ b/check_test.go
@@ -11,10 +11,12 @@ import (
 
 var (
 	testPullRequests = []*resource.PullRequest{
-		createTestPR(1, true),
-		createTestPR(2, false),
-		createTestPR(3, false),
-		createTestPR(4, false),
+		createTestPR(1, true, false),
+		createTestPR(2, false, false),
+		createTestPR(3, false, false),
+		createTestPR(4, false, false),
+		createTestPR(5, false, true),
+		createTestPR(6, false, false),
 	}
 )
 
@@ -118,6 +120,21 @@ func TestCheck(t *testing.T) {
 			pullRequests: testPullRequests,
 			expected: resource.CheckResponse{
 				resource.NewVersion(testPullRequests[0]),
+			},
+		},
+		{
+			description: "check correctly ignores cross repo pull requests",
+			source: resource.Source{
+				Repository:   "itsdalmo/test-repository",
+				AccessToken:  "oauthtoken",
+				DisableForks: true,
+			},
+			version:      resource.NewVersion(testPullRequests[5]),
+			pullRequests: testPullRequests,
+			expected: resource.CheckResponse{
+				resource.NewVersion(testPullRequests[3]),
+				resource.NewVersion(testPullRequests[2]),
+				resource.NewVersion(testPullRequests[1]),
 			},
 		},
 	}

--- a/in_test.go
+++ b/in_test.go
@@ -39,7 +39,7 @@ func TestGet(t *testing.T) {
 				CommittedDate: time.Time{},
 			},
 			parameters:     resource.GetParameters{},
-			pullRequest:    createTestPR(1, false),
+			pullRequest:    createTestPR(1, false, false),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
 			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
 		},
@@ -135,7 +135,7 @@ func TestGetSkipDownload(t *testing.T) {
 	}
 }
 
-func createTestPR(count int, skipCI bool) *resource.PullRequest {
+func createTestPR(count int, skipCI bool, isCrossRepo bool) *resource.PullRequest {
 	n := strconv.Itoa(count)
 	d := time.Now().AddDate(0, 0, -count)
 	m := fmt.Sprintf("commit message%s", n)
@@ -154,6 +154,7 @@ func createTestPR(count int, skipCI bool) *resource.PullRequest {
 			Repository: struct{ URL string }{
 				URL: fmt.Sprintf("repo%s url", n),
 			},
+			IsCrossRepository: isCrossRepo,
 		},
 		Tip: resource.CommitObject{
 			ID:            fmt.Sprintf("commit%s", n),

--- a/models.go
+++ b/models.go
@@ -18,6 +18,7 @@ type Source struct {
 	IgnorePaths         []string `json:"ignore_paths"`
 	DisableCISkip       bool     `json:"disable_ci_skip"`
 	SkipSSLVerification bool     `json:"skip_ssl_verification"`
+	DisableForks        bool     `json:"disable_forks"`
 }
 
 // Validate the source configuration.
@@ -85,6 +86,7 @@ type PullRequestObject struct {
 	Repository  struct {
 		URL string
 	}
+	IsCrossRepository bool
 }
 
 // CommitObject represents the GraphQL commit node.

--- a/out_test.go
+++ b/out_test.go
@@ -32,7 +32,7 @@ func TestPut(t *testing.T) {
 				CommittedDate: time.Time{},
 			},
 			parameters:  resource.PutParameters{},
-			pullRequest: createTestPR(1, false),
+			pullRequest: createTestPR(1, false, false),
 		},
 
 		{
@@ -49,7 +49,7 @@ func TestPut(t *testing.T) {
 			parameters: resource.PutParameters{
 				Status: "success",
 			},
-			pullRequest: createTestPR(1, false),
+			pullRequest: createTestPR(1, false, false),
 		},
 
 		{
@@ -67,7 +67,7 @@ func TestPut(t *testing.T) {
 				Status:  "failure",
 				Context: "build",
 			},
-			pullRequest: createTestPR(1, false),
+			pullRequest: createTestPR(1, false, false),
 		},
 
 		{
@@ -84,7 +84,7 @@ func TestPut(t *testing.T) {
 			parameters: resource.PutParameters{
 				Comment: "comment",
 			},
-			pullRequest: createTestPR(1, false),
+			pullRequest: createTestPR(1, false, false),
 		},
 	}
 


### PR DESCRIPTION
#### What

Implement the `disable_forks` parameter, which stops the resource from triggering if the pull request's repository is different from the resource's repository.

For more information search for `isCrossRepository` on [GitHub's API documentation](https://developer.github.com/v4/object/pullrequest/)

#### Why

I would like to be able to configure the resource to only trigger on pull requests using branches rather than forks. This is so we can use GitHub's collaborator/team permissions instead of doing an author validation step in a task.

#### Pull request

- [x] Implements a test for this feature
- [x] Implements the feature
- [x] Updates the documentation in `README.md`

#### Other

This pull request does not implement an end to end test for this functionality, just a unit test. Personally I think that an end-to-end test would just be testing GitHub's implementation.

Please let me know if there is further work that you require before considering this feature.