### PR TITLE
Add support for git-crypt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ RUN make build
 
 FROM alpine:3.8 as resource
 COPY --from=builder /go/src/github.com/telia-oss/github-pr-resource/build /opt/resource
-RUN apk add --update --no-cache \ 
+RUN apk add --update --no-cache \
     git \
     openssh \
     && chmod +x /opt/resource/*
+ADD scripts/install_git_crypt.sh install_git_crypt.sh
+RUN ./install_git_crypt.sh && rm ./install_git_crypt.sh
 
 FROM resource
 LABEL MAINTAINER=telia-oss

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `disable_ci_skip`       | No       | `true`                           | Disable ability to skip builds with `[ci skip]` and `[skip ci]` in commit message or pull request title.                                                                                                                                                                                   |
 | `skip_ssl_verification` | No       | `true`                           | Disable SSL/TLS certificate validation on git and API clients. Use with care!                                                                                                                                                                                                              |
 | `disable_forks`         | No       | `true`                           | Disable triggering of the resource if the pull request's fork repository is different to the configured repository.                                                                                                                                                                        |
+| `git_crypt_key`         | No       | `AEdJVENSWVBUS0VZAAAAA...`       | Base64 encoded git-crypt key. Setting this will unlock / decrypt the repository with git-crypt. To get the key simply execute `git-crypt export-key -- - | base64` in an encrypted repository.
+
 
 Notes:
  - If `v3_endpoint` is set, `v4_endpoint` must also be set (and the other way around).
@@ -73,6 +75,8 @@ requested version and the metadata emitted by `get` are available to your tasks 
 When specifying `skip_download` the pull request volume mounted to subsequent tasks will be empty, which is a problem 
 when you set e.g. the pending status before running the actual tests. The workaround for this is to use an alias for 
 the `put` (see https://github.com/telia-oss/github-pr-resource/issues/32 for more details).
+
+git-crypt encrypted repositories will automatically be decrypted when the `git_crypt_key` is set in the source configuration.
 
 ```yaml
 put: update-status <-- Use an alias for the pull-request resource

--- a/in.go
+++ b/in.go
@@ -42,6 +42,12 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 		return nil, err
 	}
 
+	if request.Source.GitCryptKey != "" {
+		if err := git.GitCryptUnlock(request.Source.GitCryptKey); err != nil {
+			return nil, err
+		}
+	}
+
 	// Create the metadata
 	var metadata Metadata
 	metadata.Add("pr", strconv.Itoa(pull.Number))

--- a/in_test.go
+++ b/in_test.go
@@ -135,6 +135,81 @@ func TestGetSkipDownload(t *testing.T) {
 	}
 }
 
+func TestGetGitCrypt(t *testing.T) {
+
+	tests := []struct {
+		description    string
+		source         resource.Source
+		version        resource.Version
+		parameters     resource.GetParameters
+		pullRequest    *resource.PullRequest
+		versionString  string
+		metadataString string
+	}{
+		{
+			description: "get works",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				AccessToken: "oauthtoken",
+				GitCryptKey: "gitcryptkey",
+			},
+			version: resource.Version{
+				PR:            "pr1",
+				Commit:        "commit1",
+				CommittedDate: time.Time{},
+			},
+			parameters:     resource.GetParameters{},
+			pullRequest:    createTestPR(1, false, false),
+			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			github := mocks.NewMockGithub(ctrl)
+			github.EXPECT().GetPullRequest(tc.version.PR, tc.version.Commit).Times(1).Return(tc.pullRequest, nil)
+
+			git := mocks.NewMockGit(ctrl)
+			gomock.InOrder(
+				git.EXPECT().Init(tc.pullRequest.BaseRefName).Times(1).Return(nil),
+				git.EXPECT().Pull(tc.pullRequest.Repository.URL, tc.pullRequest.BaseRefName).Times(1).Return(nil),
+				git.EXPECT().RevParse(tc.pullRequest.BaseRefName).Times(1).Return("sha", nil),
+				git.EXPECT().Fetch(tc.pullRequest.Repository.URL, tc.pullRequest.Number).Times(1).Return(nil),
+				git.EXPECT().Merge(tc.pullRequest.Tip.OID).Times(1).Return(nil),
+				git.EXPECT().GitCryptUnlock(tc.source.GitCryptKey).Times(1).Return(nil),
+			)
+
+			dir := createTestDirectory(t)
+			defer os.RemoveAll(dir)
+
+			// Run the get and check output
+			input := resource.GetRequest{Source: tc.source, Version: tc.version, Params: tc.parameters}
+			output, err := resource.Get(input, github, git, dir)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if got, want := output.Version, tc.version; !reflect.DeepEqual(got, want) {
+				t.Errorf("\ngot:\n%v\nwant:\n%v\n", got, want)
+			}
+
+			// Verify written files
+			version := readTestFile(t, filepath.Join(dir, ".git", "resource", "version.json"))
+			if got, want := version, tc.versionString; got != want {
+				t.Errorf("\ngot:\n%v\nwant:\n%v\n", got, want)
+			}
+
+			metadata := readTestFile(t, filepath.Join(dir, ".git", "resource", "metadata.json"))
+			if got, want := metadata, tc.metadataString; got != want {
+				t.Errorf("\ngot:\n%v\nwant:\n%v\n", got, want)
+			}
+		})
+	}
+}
+
 func createTestPR(count int, skipCI bool, isCrossRepo bool) *resource.PullRequest {
 	n := strconv.Itoa(count)
 	d := time.Now().AddDate(0, 0, -count)

--- a/mocks/mock_git.go
+++ b/mocks/mock_git.go
@@ -44,6 +44,18 @@ func (mr *MockGitMockRecorder) Fetch(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockGit)(nil).Fetch), arg0, arg1)
 }
 
+// GitCryptUnlock mocks base method
+func (m *MockGit) GitCryptUnlock(arg0 string) error {
+	ret := m.ctrl.Call(m, "GitCryptUnlock", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GitCryptUnlock indicates an expected call of GitCryptUnlock
+func (mr *MockGitMockRecorder) GitCryptUnlock(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GitCryptUnlock", reflect.TypeOf((*MockGit)(nil).GitCryptUnlock), arg0)
+}
+
 // Init mocks base method
 func (m *MockGit) Init(arg0 string) error {
 	ret := m.ctrl.Call(m, "Init", arg0)

--- a/models.go
+++ b/models.go
@@ -19,6 +19,7 @@ type Source struct {
 	DisableCISkip       bool     `json:"disable_ci_skip"`
 	SkipSSLVerification bool     `json:"skip_ssl_verification"`
 	DisableForks        bool     `json:"disable_forks"`
+	GitCryptKey         string   `json:"git_crypt_key"`
 }
 
 // Validate the source configuration.

--- a/scripts/install_git_crypt.sh
+++ b/scripts/install_git_crypt.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eu
+
+_main() {
+  apk add --update --no-cache curl make g++ libressl libressl-dev
+  local tmpdir
+  tmpdir="$(mktemp -d git_crypt_install.XXXXXX)"
+
+  cd "$tmpdir"
+  curl -Lo git-crypt-0.6.0.tar.gz https://www.agwa.name/projects/git-crypt/downloads/git-crypt-0.6.0.tar.gz
+  tar -zxf git-crypt-0.6.0.tar.gz
+  cd git-crypt-0.6.0
+  make
+  make install
+  cd ..
+  rm -rf "$tmpdir"
+
+  apk del curl make libressl libressl-dev
+}
+
+_main "$@"


### PR DESCRIPTION
Resolves #67 

This PR adds support for [git-crypt](https://www.agwa.name/projects/git-crypt/), to better align with the official git resource.

I've added a `git_crypt_key` source configuration param, that - when provided - will cause the repo to be unlocked using `git-crypt` during the `get` step.

Apart from the unit tests, I would like to include e2e tests but I didn't find an obvious way to do it, since the repo used by the tests is archived. However, I've tested this in a personal pipeline at https://concourse.our.buildo.io/teams/buildo/pipelines/gitcrypt

Notice how [build 3](https://concourse.our.buildo.io/teams/buildo/pipelines/gitcrypt/jobs/test/builds/3) (which lacks the `git_crypt_key` parameter) prints the encrypted content of the file, while [build 6](https://concourse.our.buildo.io/teams/buildo/pipelines/gitcrypt/jobs/test/builds/6) (which has the `git_crypt_key` parameter set) prints the decrypted content.

I've tried to adhere to the project's style as much as possible, but this is the first Go code I've ever written that goes beyond an hello world so I'll appreciate stylistic comments ^^

