### PR TITLE
Fix unhandled error in GitCryptUnlock

### DIFF
--- a/git.go
+++ b/git.go
@@ -135,7 +135,9 @@ func (g *GitClient) GitCryptUnlock(base64key string) error {
 		return fmt.Errorf("failed to decode git-crypt key")
 	}
 	keyPath := filepath.Join(keyDir, "git-crypt-key")
-	ioutil.WriteFile(keyPath, decodedKey, 600)
+	if err := ioutil.WriteFile(keyPath, decodedKey, 600); err != nil {
+		return fmt.Errorf("failed to write git-crypt key to file: %s", err)
+	}
 	if err := g.command("git-crypt", "unlock", keyPath).Run(); err != nil {
 		return fmt.Errorf("git-crypt unlock failed: %s", err)
 	}


### PR DESCRIPTION
`ioutil.WriteFile` can return an error, we should check it.