### PR TITLE
Cleanup git-crypt build dependnecies more aggressively

### DIFF
--- a/scripts/install_git_crypt.sh
+++ b/scripts/install_git_crypt.sh
@@ -3,7 +3,8 @@
 set -eu
 
 _main() {
-  apk add --update --no-cache curl make g++ libressl libressl-dev
+  apk --update add --virtual=.build-deps curl make g++ openssl-dev
+  apk add --no-cache libgcc libstdc++ openssl
   local tmpdir
   tmpdir="$(mktemp -d git_crypt_install.XXXXXX)"
 
@@ -16,7 +17,7 @@ _main() {
   cd ..
   rm -rf "$tmpdir"
 
-  apk del curl make libressl libressl-dev
+  apk del .build-deps
 }
 
 _main "$@"

--- a/scripts/install_git_crypt.sh
+++ b/scripts/install_git_crypt.sh
@@ -18,6 +18,7 @@ _main() {
   rm -rf "$tmpdir"
 
   apk del .build-deps
+  rm -rf /var/cache/apk/*
 }
 
 _main "$@"


### PR DESCRIPTION
Fixes #87 

In my previous PR (#70) I've accidentally increased the size of the Docker image, by not cleaning up build dependencies properly.

This PR fixes it, making git-crypt adding only 6.25MB (instead of 151MB) in size.

Before this PR:

```
❯ docker history 371436e62541
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
371436e62541        6 seconds ago       /bin/sh -c #(nop)  LABEL MAINTAINER=telia-oss   0B
157a1781690f        6 seconds ago       /bin/sh -c ./install_git_crypt.sh && rm ./in…   151MB
73a96fb7985a        24 seconds ago      /bin/sh -c #(nop) ADD file:be794c3b86c757fb2…   445B
26d8ad33d89c        16 minutes ago      /bin/sh -c apk add --update --no-cache     g…   34.3MB
f4d36fcc7ee4        16 minutes ago      /bin/sh -c #(nop) COPY dir:3d56086afe144d715…   15.3MB
3f53bb00af94        3 months ago        /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
<missing>           3 months ago        /bin/sh -c #(nop) ADD file:2ff00caea4e83dfad…   4.41MB
```

After this PR:

```
❯ docker history 8cd6942f160e
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
8cd6942f160e        26 seconds ago      /bin/sh -c #(nop)  LABEL MAINTAINER=telia-oss   0B
566f066a153d        27 seconds ago      /bin/sh -c ./install_git_crypt.sh && rm ./in…   6.25MB
46a97200a0c1        42 seconds ago      /bin/sh -c #(nop) ADD file:2404d5c851ae13d47…   498B
26d8ad33d89c        21 minutes ago      /bin/sh -c apk add --update --no-cache     g…   34.3MB
f4d36fcc7ee4        21 minutes ago      /bin/sh -c #(nop) COPY dir:3d56086afe144d715…   15.3MB
3f53bb00af94        3 months ago        /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
<missing>           3 months ago        /bin/sh -c #(nop) ADD file:2ff00caea4e83dfad…   4.41MB
```