### PR TITLE
Add new configuration options: base_context, target_url, interpolation env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `disable_forks`         | No       | `true`                           | Disable triggering of the resource if the pull request's fork repository is different to the configured repository.                                                                                                                                                                        |
 | `git_crypt_key`         | No       | `AEdJVENSWVBUS0VZAAAAA...`       | Base64 encoded git-crypt key. Setting this will unlock / decrypt the repository with git-crypt. To get the key simply execute `git-crypt export-key -- - | base64` in an encrypted repository.                                                                                             |
 | `base_branch`           | No       | `master`                         | Name of a branch. The pipeline will only trigger on pull requests against the specified branch.                                                                                                                                                                                            |
-| `integration_tool`      | No       | `rebase`                         | The integration tool to use, `merge` or `rebase`. Defaults to `merge`.
-| `base_context`          | No       | `concourse-ci`                   | Change the default prepended name of the context.  For example: concourse-ci/status, base context will be concourse-ci.
-| `target_url`            | No       | `ATC DEFAULT URL`                | The base URL for the Concourse deployment, used for linking to builds.
-| `description`           | No       | `Concourse CI build`             | The description status on the specified pull request.                                                                                                                             |
+| `integration_tool`      | No       | `rebase`                         | The integration tool to use, `merge` or `rebase`. Defaults to `merge`.                          |
 
 Notes:
  - If `v3_endpoint` is set, `v4_endpoint` must also be set (and the other way around).
@@ -99,15 +96,16 @@ empty commit to the PR*.
 
 #### `put`
 
-| Parameter      | Required | Example                 | Description                                                                                         |
-|----------------|----------|-------------------------|-----------------------------------------------------------------------------------------------------|
-| `path`         | Yes      | `pull-request`          | The name given to the resource in a GET step.                                                       |
-| `status`       | No       | `SUCCESS`               | Set a status on a commit. One of `SUCCESS`, `PENDING`, `FAILURE` and `ERROR`.                       |
-| `context`      | No       | `unit-test`             | A context to use for the status. (Prefixed with `concourse-ci`, defaults to `concourse-ci/status`). |
-| `comment`      | No       | `hello world!`          | A comment to add to the pull request.                                                               |
-| `comment_file` | No       | `my-output/comment.txt` | Path to file containing a comment to add to the pull request (e.g. output of `terraform plan`).     |
-| `target_url`   | No       | `ATC DEFAULT URL`       | The base URL for the Concourse deployment, used for linking to builds.                              |
-| `description`  | No       | `Concourse CI build %s` | The description status on the specified pull request.                                               |
+| Parameter      | Required | Example                 | Description                                                                                                             |
+|----------------|----------|-------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `path`         | Yes      | `pull-request`          | The name given to the resource in a GET step.                                                                           |
+| `status`       | No       | `SUCCESS`               | Set a status on a commit. One of `SUCCESS`, `PENDING`, `FAILURE` and `ERROR`.                                           |
+| `base_context` | No       | `concourse-ci`          | Change the default prepended name of the context.  For example: concourse-ci/status, base context will be concourse-ci. |
+| `context`      | No       | `unit-test`             | A context to use for the status. (Prefixed with `concourse-ci`, defaults to `concourse-ci/status`).                     |
+| `comment`      | No       | `hello world!`          | A comment to add to the pull request.                                                                                   |
+| `comment_file` | No       | `my-output/comment.txt` | Path to file containing a comment to add to the pull request (e.g. output of `terraform plan`).                         |
+| `target_url`   | No       | `ATC DEFAULT URL`       | The base URL for the Concourse deployment, used for linking to builds.                                                  |
+| `description`  | No       | `Concourse CI build %s` | The description status on the specified pull request.                                                                   |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `integration_tool`      | No       | `rebase`                         | The integration tool to use, `merge` or `rebase`. Defaults to `merge`.
 | `base_context`          | No       | `concourse-ci`                   | Change the default prepended name of the context.  For example: concourse-ci/status, base context will be concourse-ci.
 | `target_url`            | No       | `ATC DEFAULT URL`                | The base URL for the Concourse deployment, used for linking to builds.
-| `description`           | No       | `Concourse CI build %s`          | The description status on the specified pull request.                                                                                                                             |
+| `description`           | No       | `Concourse CI build`             | The description status on the specified pull request.                                                                                                                             |
 
 Notes:
  - If `v3_endpoint` is set, `v4_endpoint` must also be set (and the other way around).

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `disable_forks`         | No       | `true`                           | Disable triggering of the resource if the pull request's fork repository is different to the configured repository.                                                                                                                                                                        |
 | `git_crypt_key`         | No       | `AEdJVENSWVBUS0VZAAAAA...`       | Base64 encoded git-crypt key. Setting this will unlock / decrypt the repository with git-crypt. To get the key simply execute `git-crypt export-key -- - | base64` in an encrypted repository.                                                                                             |
 | `base_branch`           | No       | `master`                         | Name of a branch. The pipeline will only trigger on pull requests against the specified branch.                                                                                                                                                                                            |
-| `integration_tool`      | No       | `rebase`                         | The integration tool to use, `merge` or `rebase`. Defaults to `merge`.                                                                                                                                                                                                                     |
-
+| `integration_tool`      | No       | `rebase`                         | The integration tool to use, `merge` or `rebase`. Defaults to `merge`.
+| `base_context`          | No       | `concourse-ci`                   | Change the default prepended name of the context.  For example: concourse-ci/status, base context will be concourse-ci.
+| `target_url`            | No       | `ATC DEFAULT URL`                | The base URL for the Concourse deployment, used for linking to builds.
+| `description`           | No       | `Concourse CI build %s`          | The description status on the specified pull request.                                                                                                                             |
 
 Notes:
  - If `v3_endpoint` is set, `v4_endpoint` must also be set (and the other way around).
@@ -69,13 +71,13 @@ generate notifications over the webhook. So if you have a repository with little
 Clones the base (e.g. `master` branch) at the latest commit, and merges the pull request at the specified commit
 into master. This ensures that we are both testing and setting status on the exact commit that was requested in
 input. Because the base of the PR is not locked to a specific commit in versions emitted from `check`, a fresh
-`get` will always use the latest commit in master and *report the SHA of said commit in the metadata*. Both the 
+`get` will always use the latest commit in master and *report the SHA of said commit in the metadata*. Both the
 requested version and the metadata emitted by `get` are available to your tasks as JSON:
 - `.git/resource/version.json`
 - `.git/resource/metadata.json`
 
-When specifying `skip_download` the pull request volume mounted to subsequent tasks will be empty, which is a problem 
-when you set e.g. the pending status before running the actual tests. The workaround for this is to use an alias for 
+When specifying `skip_download` the pull request volume mounted to subsequent tasks will be empty, which is a problem
+when you set e.g. the pending status before running the actual tests. The workaround for this is to use an alias for
 the `put` (see https://github.com/telia-oss/github-pr-resource/issues/32 for more details).
 
 git-crypt encrypted repositories will automatically be decrypted when the `git_crypt_key` is set in the source configuration.
@@ -84,14 +86,14 @@ git-crypt encrypted repositories will automatically be decrypted when the `git_c
 put: update-status <-- Use an alias for the pull-request resource
 resource: pull-request
 params:
-    path: pull-request 
-    status: pending 
+    path: pull-request
+    status: pending
 get_params: {skip_download: true}
 ```
 
 Note that, should you retrigger a build in the hopes of testing the last commit to a PR against a newer version of
 the base, Concourse will reuse the volume (i.e. not trigger a new `get`) if it still exists, which can produce
-unexpected results (#5). As such, re-testing a PR against a newer version of the base is best done by *pushing an 
+unexpected results (#5). As such, re-testing a PR against a newer version of the base is best done by *pushing an
 empty commit to the PR*.
 
 
@@ -104,6 +106,8 @@ empty commit to the PR*.
 | `context`      | No       | `unit-test`             | A context to use for the status. (Prefixed with `concourse-ci`, defaults to `concourse-ci/status`). |
 | `comment`      | No       | `hello world!`          | A comment to add to the pull request.                                                               |
 | `comment_file` | No       | `my-output/comment.txt` | Path to file containing a comment to add to the pull request (e.g. output of `terraform plan`).     |
+| `target_url`   | No       | `ATC DEFAULT URL`       | The base URL for the Concourse deployment, used for linking to builds.                              |
+| `description`  | No       | `Concourse CI build %s` | The description status on the specified pull request.                                               |
 
 ## Example
 
@@ -192,6 +196,7 @@ If you are coming from [jtarchie/github-pullrequest-resource][original-resource]
   - `ci_skip` -> `disable_ci_skip` (the logic has been inverted and its `true` by default)
   - `api_endpoint` -> `v3_endpoint`
   - `base` -> `base_branch`
+  - `base_url` -> `target_url`
 - `put`:
   - `comment` -> `comment_file` (because we added `comment`)
 

--- a/fakes/fake_github.go
+++ b/fakes/fake_github.go
@@ -59,7 +59,7 @@ type FakeGithub struct {
 	postCommentReturnsOnCall map[int]struct {
 		result1 error
 	}
-	UpdateCommitStatusStub        func(string, string, string, string, string) error
+	UpdateCommitStatusStub        func(string, string, string, string, string, string) error
 	updateCommitStatusMutex       sync.RWMutex
 	updateCommitStatusArgsForCall []struct {
 		arg1 string
@@ -67,6 +67,7 @@ type FakeGithub struct {
 		arg3 string
 		arg4 string
 		arg5 string
+		arg6 string
 	}
 	updateCommitStatusReturns struct {
 		result1 error
@@ -321,7 +322,7 @@ func (fake *FakeGithub) PostCommentReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeGithub) UpdateCommitStatus(arg1 string, arg2 string, arg3 string, arg4 string, arg5 string) error {
+func (fake *FakeGithub) UpdateCommitStatus(arg1 string, arg2 string, arg3 string, arg4 string, arg5 string, arg6 string) error {
 	fake.updateCommitStatusMutex.Lock()
 	ret, specificReturn := fake.updateCommitStatusReturnsOnCall[len(fake.updateCommitStatusArgsForCall)]
 	fake.updateCommitStatusArgsForCall = append(fake.updateCommitStatusArgsForCall, struct {
@@ -330,11 +331,12 @@ func (fake *FakeGithub) UpdateCommitStatus(arg1 string, arg2 string, arg3 string
 		arg3 string
 		arg4 string
 		arg5 string
-	}{arg1, arg2, arg3, arg4, arg5})
-	fake.recordInvocation("UpdateCommitStatus", []interface{}{arg1, arg2, arg3, arg4, arg5})
+		arg6 string
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	fake.recordInvocation("UpdateCommitStatus", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.updateCommitStatusMutex.Unlock()
 	if fake.UpdateCommitStatusStub != nil {
-		return fake.UpdateCommitStatusStub(arg1, arg2, arg3, arg4, arg5)
+		return fake.UpdateCommitStatusStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1
@@ -349,17 +351,17 @@ func (fake *FakeGithub) UpdateCommitStatusCallCount() int {
 	return len(fake.updateCommitStatusArgsForCall)
 }
 
-func (fake *FakeGithub) UpdateCommitStatusCalls(stub func(string, string, string, string, string) error) {
+func (fake *FakeGithub) UpdateCommitStatusCalls(stub func(string, string, string, string, string, string) error) {
 	fake.updateCommitStatusMutex.Lock()
 	defer fake.updateCommitStatusMutex.Unlock()
 	fake.UpdateCommitStatusStub = stub
 }
 
-func (fake *FakeGithub) UpdateCommitStatusArgsForCall(i int) (string, string, string, string, string) {
+func (fake *FakeGithub) UpdateCommitStatusArgsForCall(i int) (string, string, string, string, string, string) {
 	fake.updateCommitStatusMutex.RLock()
 	defer fake.updateCommitStatusMutex.RUnlock()
 	argsForCall := fake.updateCommitStatusArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeGithub) UpdateCommitStatusReturns(result1 error) {

--- a/fakes/fake_github.go
+++ b/fakes/fake_github.go
@@ -59,12 +59,14 @@ type FakeGithub struct {
 	postCommentReturnsOnCall map[int]struct {
 		result1 error
 	}
-	UpdateCommitStatusStub        func(string, string, string) error
+	UpdateCommitStatusStub        func(string, string, string, string, string) error
 	updateCommitStatusMutex       sync.RWMutex
 	updateCommitStatusArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
+		arg4 string
+		arg5 string
 	}
 	updateCommitStatusReturns struct {
 		result1 error
@@ -319,18 +321,20 @@ func (fake *FakeGithub) PostCommentReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeGithub) UpdateCommitStatus(arg1 string, arg2 string, arg3 string) error {
+func (fake *FakeGithub) UpdateCommitStatus(arg1 string, arg2 string, arg3 string, arg4 string, arg5 string) error {
 	fake.updateCommitStatusMutex.Lock()
 	ret, specificReturn := fake.updateCommitStatusReturnsOnCall[len(fake.updateCommitStatusArgsForCall)]
 	fake.updateCommitStatusArgsForCall = append(fake.updateCommitStatusArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("UpdateCommitStatus", []interface{}{arg1, arg2, arg3})
+		arg4 string
+		arg5 string
+	}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("UpdateCommitStatus", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.updateCommitStatusMutex.Unlock()
 	if fake.UpdateCommitStatusStub != nil {
-		return fake.UpdateCommitStatusStub(arg1, arg2, arg3)
+		return fake.UpdateCommitStatusStub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -345,17 +349,17 @@ func (fake *FakeGithub) UpdateCommitStatusCallCount() int {
 	return len(fake.updateCommitStatusArgsForCall)
 }
 
-func (fake *FakeGithub) UpdateCommitStatusCalls(stub func(string, string, string) error) {
+func (fake *FakeGithub) UpdateCommitStatusCalls(stub func(string, string, string, string, string) error) {
 	fake.updateCommitStatusMutex.Lock()
 	defer fake.updateCommitStatusMutex.Unlock()
 	fake.UpdateCommitStatusStub = stub
 }
 
-func (fake *FakeGithub) UpdateCommitStatusArgsForCall(i int) (string, string, string) {
+func (fake *FakeGithub) UpdateCommitStatusArgsForCall(i int) (string, string, string, string, string) {
 	fake.updateCommitStatusMutex.RLock()
 	defer fake.updateCommitStatusMutex.RUnlock()
 	argsForCall := fake.updateCommitStatusArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeGithub) UpdateCommitStatusReturns(result1 error) {

--- a/models.go
+++ b/models.go
@@ -27,9 +27,6 @@ type Source struct {
 	GitCryptKey         string   `json:"git_crypt_key"`
 	BaseBranch          string   `json:"base_branch"`
 	IntegrationTool     string   `json:"integration_tool"`
-	BaseContext         string   `json:"base_context"`
-	TargetURL           string   `json:"target_url"`
-	Description         string   `json:"description"`
 }
 
 // Validate the source configuration.

--- a/models.go
+++ b/models.go
@@ -27,6 +27,9 @@ type Source struct {
 	GitCryptKey         string   `json:"git_crypt_key"`
 	BaseBranch          string   `json:"base_branch"`
 	IntegrationTool     string   `json:"integration_tool"`
+	BaseContext         string   `json:"base_context"`
+	TargetURL           string   `json:"target_url"`
+	Description         string   `json:"description"`
 }
 
 // Validate the source configuration.

--- a/out.go
+++ b/out.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -37,14 +38,14 @@ func Put(request PutRequest, manager Github, inputDir string) (*PutResponse, err
 
 	// Set status if specified
 	if status := request.Params.Status; status != "" {
-		if err := manager.UpdateCommitStatus(version.Commit, request.Params.Context, status); err != nil {
+		if err := manager.UpdateCommitStatus(version.Commit, request.Params.Context, status, os.ExpandEnv(request.Params.TargetURL), request.Params.Description); err != nil {
 			return nil, fmt.Errorf("failed to set status: %s", err)
 		}
 	}
 
 	// Set comment if specified
 	if comment := request.Params.Comment; comment != "" {
-		err = manager.PostComment(version.PR, comment)
+		err = manager.PostComment(version.PR, os.ExpandEnv(comment))
 		if err != nil {
 			return nil, fmt.Errorf("failed to post comment: %s", err)
 		}
@@ -59,7 +60,7 @@ func Put(request PutRequest, manager Github, inputDir string) (*PutResponse, err
 		}
 		comment := string(content)
 		if comment != "" {
-			err = manager.PostComment(version.PR, comment)
+			err = manager.PostComment(version.PR, os.ExpandEnv(comment))
 			if err != nil {
 				return nil, fmt.Errorf("failed to post comment: %s", err)
 			}
@@ -87,7 +88,10 @@ type PutResponse struct {
 // PutParameters for the resource.
 type PutParameters struct {
 	Path        string `json:"path"`
+	BaseContext string `json:"base_context"`
 	Context     string `json:"context"`
+	TargetURL   string `json:"target_url"`
+	Description string `json:"description"`
 	Status      string `json:"status"`
 	CommentFile string `json:"comment_file"`
 	Comment     string `json:"comment"`

--- a/out.go
+++ b/out.go
@@ -38,7 +38,7 @@ func Put(request PutRequest, manager Github, inputDir string) (*PutResponse, err
 
 	// Set status if specified
 	if status := request.Params.Status; status != "" {
-		if err := manager.UpdateCommitStatus(version.Commit, request.Params.Context, status, os.ExpandEnv(request.Params.TargetURL), request.Params.Description); err != nil {
+		if err := manager.UpdateCommitStatus(version.Commit, request.Params.BaseContext, request.Params.Context, status, os.ExpandEnv(request.Params.TargetURL), request.Params.Description); err != nil {
 			return nil, fmt.Errorf("failed to set status: %s", err)
 		}
 	}

--- a/out_test.go
+++ b/out_test.go
@@ -1,6 +1,7 @@
 package resource_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -71,6 +72,97 @@ func TestPut(t *testing.T) {
 		},
 
 		{
+			description: "we can provide a custom base context for the status",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				AccessToken: "oauthtoken",
+				BaseContext: "concourse-ci-custom",
+			},
+			version: resource.Version{
+				PR:            "pr1",
+				Commit:        "commit1",
+				CommittedDate: time.Time{},
+			},
+			parameters: resource.PutParameters{
+				Status:  "failure",
+				Context: "build",
+			},
+			pullRequest: createTestPR(1, "master", false, false),
+		},
+
+		{
+			description: "we can provide a custom target url for the status",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				AccessToken: "oauthtoken",
+			},
+			version: resource.Version{
+				PR:            "pr1",
+				Commit:        "commit1",
+				CommittedDate: time.Time{},
+			},
+			parameters: resource.PutParameters{
+				Status:    "failure",
+				TargetURL: "https://targeturl.com/concourse",
+			},
+			pullRequest: createTestPR(1, "master", false, false),
+		},
+
+		{
+			description: "we can provide a custom target url for the status on source",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				AccessToken: "oauthtoken",
+				TargetURL:   "https://targeturl.com/concourse",
+			},
+			version: resource.Version{
+				PR:            "pr1",
+				Commit:        "commit1",
+				CommittedDate: time.Time{},
+			},
+			parameters: resource.PutParameters{
+				Status: "failure",
+			},
+			pullRequest: createTestPR(1, "master", false, false),
+		},
+
+		{
+			description: "we can provide a custom description for the status",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				AccessToken: "oauthtoken",
+			},
+			version: resource.Version{
+				PR:            "pr1",
+				Commit:        "commit1",
+				CommittedDate: time.Time{},
+			},
+			parameters: resource.PutParameters{
+				Status:      "failure",
+				Description: "Concourse CI build",
+			},
+			pullRequest: createTestPR(1, "master", false, false),
+		},
+
+		{
+			description: "we can provide a custom description for the status on source",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				AccessToken: "oauthtoken",
+				Description: "Concourse CI build",
+			},
+			version: resource.Version{
+				PR:            "pr1",
+				Commit:        "commit1",
+				CommittedDate: time.Time{},
+			},
+			parameters: resource.PutParameters{
+				Status: "failure",
+			},
+			pullRequest: createTestPR(1, "master", false, false),
+		},
+
+		{
 			description: "we can comment on the pull request",
 			source: resource.Source{
 				Repository:  "itsdalmo/test-repository",
@@ -116,9 +208,11 @@ func TestPut(t *testing.T) {
 			// Validate method calls put on Github.
 			if tc.parameters.Status != "" {
 				if assert.Equal(t, 1, github.UpdateCommitStatusCallCount()) {
-					commit, context, status := github.UpdateCommitStatusArgsForCall(0)
+					commit, context, status, targetURL, description := github.UpdateCommitStatusArgsForCall(0)
 					assert.Equal(t, tc.version.Commit, commit)
 					assert.Equal(t, tc.parameters.Context, context)
+					assert.Equal(t, tc.parameters.TargetURL, targetURL)
+					assert.Equal(t, tc.parameters.Description, description)
 					assert.Equal(t, tc.parameters.Status, status)
 				}
 			}
@@ -129,6 +223,104 @@ func TestPut(t *testing.T) {
 					assert.Equal(t, tc.parameters.Comment, comment)
 				}
 			}
+		})
+	}
+}
+
+func TestVariableSubstitution(t *testing.T) {
+
+	var (
+		variableName  = "EXAMPLE_VARIABLE"
+		variableValue = "value"
+		variableURL   = "https://concourse-ci.org/"
+	)
+
+	tests := []struct {
+		description       string
+		source            resource.Source
+		version           resource.Version
+		parameters        resource.PutParameters
+		expectedComment   string
+		expectedTargetURL string
+		pullRequest       *resource.PullRequest
+	}{
+
+		{
+			description: "we can substitute environment variables for Comment",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				AccessToken: "oauthtoken",
+			},
+			version: resource.Version{
+				PR:            "pr1",
+				Commit:        "commit1",
+				CommittedDate: time.Time{},
+			},
+			parameters: resource.PutParameters{
+				Comment: fmt.Sprintf("$%s", variableName),
+			},
+			expectedComment: variableValue,
+			pullRequest:     createTestPR(1, "master", false, false),
+		},
+
+		{
+			description: "we can substitute environment variables for TargetURL",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				AccessToken: "oauthtoken",
+			},
+			version: resource.Version{
+				PR:            "pr1",
+				Commit:        "commit1",
+				CommittedDate: time.Time{},
+			},
+			parameters: resource.PutParameters{
+				Status:    "failure",
+				TargetURL: fmt.Sprintf("%s$%s", variableURL, variableName),
+			},
+			expectedTargetURL: fmt.Sprintf("%s%s", variableURL, variableValue),
+			pullRequest:       createTestPR(1, "master", false, false),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			github := new(fakes.FakeGithub)
+			github.GetPullRequestReturns(tc.pullRequest, nil)
+
+			git := new(fakes.FakeGit)
+			git.RevParseReturns("sha", nil)
+
+			dir := createTestDirectory(t)
+			defer os.RemoveAll(dir)
+
+			// Run get so we have version and metadata for the put request
+			getInput := resource.GetRequest{Source: tc.source, Version: tc.version, Params: resource.GetParameters{}}
+			_, err := resource.Get(getInput, github, git, dir)
+			require.NoError(t, err)
+
+			oldValue := os.Getenv(variableName)
+			defer os.Setenv(variableName, oldValue)
+
+			os.Setenv(variableName, variableValue)
+
+			putInput := resource.PutRequest{Source: tc.source, Params: tc.parameters}
+			_, err = resource.Put(putInput, github, dir)
+
+			if tc.parameters.TargetURL != "" {
+				if assert.Equal(t, 1, github.UpdateCommitStatusCallCount()) {
+					_, _, _, targetURL, _ := github.UpdateCommitStatusArgsForCall(0)
+					assert.Equal(t, tc.expectedTargetURL, targetURL)
+				}
+			}
+
+			if tc.parameters.Comment != "" {
+				if assert.Equal(t, 1, github.PostCommentCallCount()) {
+					_, comment := github.PostCommentArgsForCall(0)
+					assert.Equal(t, tc.expectedComment, comment)
+				}
+			}
+
 		})
 	}
 }

--- a/out_test.go
+++ b/out_test.go
@@ -76,7 +76,6 @@ func TestPut(t *testing.T) {
 			source: resource.Source{
 				Repository:  "itsdalmo/test-repository",
 				AccessToken: "oauthtoken",
-				BaseContext: "concourse-ci-custom",
 			},
 			version: resource.Version{
 				PR:            "pr1",
@@ -84,8 +83,9 @@ func TestPut(t *testing.T) {
 				CommittedDate: time.Time{},
 			},
 			parameters: resource.PutParameters{
-				Status:  "failure",
-				Context: "build",
+				Status:      "failure",
+				BaseContext: "concourse-ci-custom",
+				Context:     "build",
 			},
 			pullRequest: createTestPR(1, "master", false, false),
 		},
@@ -109,24 +109,6 @@ func TestPut(t *testing.T) {
 		},
 
 		{
-			description: "we can provide a custom target url for the status on source",
-			source: resource.Source{
-				Repository:  "itsdalmo/test-repository",
-				AccessToken: "oauthtoken",
-				TargetURL:   "https://targeturl.com/concourse",
-			},
-			version: resource.Version{
-				PR:            "pr1",
-				Commit:        "commit1",
-				CommittedDate: time.Time{},
-			},
-			parameters: resource.PutParameters{
-				Status: "failure",
-			},
-			pullRequest: createTestPR(1, "master", false, false),
-		},
-
-		{
 			description: "we can provide a custom description for the status",
 			source: resource.Source{
 				Repository:  "itsdalmo/test-repository",
@@ -140,24 +122,6 @@ func TestPut(t *testing.T) {
 			parameters: resource.PutParameters{
 				Status:      "failure",
 				Description: "Concourse CI build",
-			},
-			pullRequest: createTestPR(1, "master", false, false),
-		},
-
-		{
-			description: "we can provide a custom description for the status on source",
-			source: resource.Source{
-				Repository:  "itsdalmo/test-repository",
-				AccessToken: "oauthtoken",
-				Description: "Concourse CI build",
-			},
-			version: resource.Version{
-				PR:            "pr1",
-				Commit:        "commit1",
-				CommittedDate: time.Time{},
-			},
-			parameters: resource.PutParameters{
-				Status: "failure",
 			},
 			pullRequest: createTestPR(1, "master", false, false),
 		},
@@ -208,8 +172,9 @@ func TestPut(t *testing.T) {
 			// Validate method calls put on Github.
 			if tc.parameters.Status != "" {
 				if assert.Equal(t, 1, github.UpdateCommitStatusCallCount()) {
-					commit, context, status, targetURL, description := github.UpdateCommitStatusArgsForCall(0)
+					commit, baseContext, context, status, targetURL, description := github.UpdateCommitStatusArgsForCall(0)
 					assert.Equal(t, tc.version.Commit, commit)
+					assert.Equal(t, tc.parameters.BaseContext, baseContext)
 					assert.Equal(t, tc.parameters.Context, context)
 					assert.Equal(t, tc.parameters.TargetURL, targetURL)
 					assert.Equal(t, tc.parameters.Description, description)
@@ -309,7 +274,7 @@ func TestVariableSubstitution(t *testing.T) {
 
 			if tc.parameters.TargetURL != "" {
 				if assert.Equal(t, 1, github.UpdateCommitStatusCallCount()) {
-					_, _, _, targetURL, _ := github.UpdateCommitStatusArgsForCall(0)
+					_, _, _, _, targetURL, _ := github.UpdateCommitStatusArgsForCall(0)
 					assert.Equal(t, tc.expectedTargetURL, targetURL)
 				}
 			}


### PR DESCRIPTION
The aim of this PR is to bring some interesting features of the [original version](https://github.com/jtarchie/github-pullrequest-resource), in which this repo is inspired, to this new version. 

As a regular users, we still use the previous one because we have to configure our concourse_url, context and description in most of our pipelines.

This PR also adds environment vars interpolation in the comments and target_url params.

It should resolve this issue too: https://github.com/telia-oss/github-pr-resource/issues/77 and it is backwards compatible.

Closes #77  