### PR TITLE
Add git_depth get parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ generate notifications over the webhook. So if you have a repository with little
 |--------------------|----------|----------|--------------------------------------------------------------------------|
 | `skip_download`    | No       | `true`   | Use with `get_params` in a `put` step to do nothing on the implicit get. |
 | `integration_tool` | No       | `rebase` | The integration tool to use, `merge` or `rebase`. Defaults to `merge`.   |
+| `git_depth`        | No       | `1`      | Shallow clone the repository using the `--depth` Git option              |
 
 Clones the base (e.g. `master` branch) at the latest commit, and merges the pull request at the specified commit
 into master. This ensures that we are both testing and setting status on the exact commit that was requested in
@@ -198,6 +199,8 @@ If you are coming from [jtarchie/github-pullrequest-resource][original-resource]
   - `api_endpoint` -> `v3_endpoint`
   - `base` -> `base_branch`
   - `base_url` -> `target_url`
+- `get`:
+  - `git.depth` -> `git_depth`
 - `put`:
   - `comment` -> `comment_file` (because we added `comment`)
 
@@ -218,7 +221,7 @@ If you are coming from [jtarchie/github-pullrequest-resource][original-resource]
   - `label`
   - `git_config`: You can now get the pr/author info from .git/resource/metadata.json instead
 - `get`:
-  - `git.*`
+  - `git.*` (with the exception of `git_depth`, see above)
 - `put`:
   - `merge.*`
   - `label`

--- a/fakes/fake_git.go
+++ b/fakes/fake_git.go
@@ -53,11 +53,12 @@ type FakeGit struct {
 	mergeReturnsOnCall map[int]struct {
 		result1 error
 	}
-	PullStub        func(string, string) error
+	PullStub        func(string, string, int) error
 	pullMutex       sync.RWMutex
 	pullArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 int
 	}
 	pullReturns struct {
 		result1 error
@@ -335,17 +336,18 @@ func (fake *FakeGit) MergeReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeGit) Pull(arg1 string, arg2 string) error {
+func (fake *FakeGit) Pull(arg1 string, arg2 string, arg3 int) error {
 	fake.pullMutex.Lock()
 	ret, specificReturn := fake.pullReturnsOnCall[len(fake.pullArgsForCall)]
 	fake.pullArgsForCall = append(fake.pullArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("Pull", []interface{}{arg1, arg2})
+		arg3 int
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("Pull", []interface{}{arg1, arg2, arg3})
 	fake.pullMutex.Unlock()
 	if fake.PullStub != nil {
-		return fake.PullStub(arg1, arg2)
+		return fake.PullStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -360,17 +362,17 @@ func (fake *FakeGit) PullCallCount() int {
 	return len(fake.pullArgsForCall)
 }
 
-func (fake *FakeGit) PullCalls(stub func(string, string) error) {
+func (fake *FakeGit) PullCalls(stub func(string, string, int) error) {
 	fake.pullMutex.Lock()
 	defer fake.pullMutex.Unlock()
 	fake.PullStub = stub
 }
 
-func (fake *FakeGit) PullArgsForCall(i int) (string, string) {
+func (fake *FakeGit) PullArgsForCall(i int) (string, string, int) {
 	fake.pullMutex.RLock()
 	defer fake.pullMutex.RUnlock()
 	argsForCall := fake.pullArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeGit) PullReturns(result1 error) {

--- a/fakes/fake_git.go
+++ b/fakes/fake_git.go
@@ -8,11 +8,12 @@ import (
 )
 
 type FakeGit struct {
-	FetchStub        func(string, int) error
+	FetchStub        func(string, int, int) error
 	fetchMutex       sync.RWMutex
 	fetchArgsForCall []struct {
 		arg1 string
 		arg2 int
+		arg3 int
 	}
 	fetchReturns struct {
 		result1 error
@@ -95,17 +96,18 @@ type FakeGit struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeGit) Fetch(arg1 string, arg2 int) error {
+func (fake *FakeGit) Fetch(arg1 string, arg2 int, arg3 int) error {
 	fake.fetchMutex.Lock()
 	ret, specificReturn := fake.fetchReturnsOnCall[len(fake.fetchArgsForCall)]
 	fake.fetchArgsForCall = append(fake.fetchArgsForCall, struct {
 		arg1 string
 		arg2 int
-	}{arg1, arg2})
-	fake.recordInvocation("Fetch", []interface{}{arg1, arg2})
+		arg3 int
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("Fetch", []interface{}{arg1, arg2, arg3})
 	fake.fetchMutex.Unlock()
 	if fake.FetchStub != nil {
-		return fake.FetchStub(arg1, arg2)
+		return fake.FetchStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -120,17 +122,17 @@ func (fake *FakeGit) FetchCallCount() int {
 	return len(fake.fetchArgsForCall)
 }
 
-func (fake *FakeGit) FetchCalls(stub func(string, int) error) {
+func (fake *FakeGit) FetchCalls(stub func(string, int, int) error) {
 	fake.fetchMutex.Lock()
 	defer fake.fetchMutex.Unlock()
 	fake.FetchStub = stub
 }
 
-func (fake *FakeGit) FetchArgsForCall(i int) (string, int) {
+func (fake *FakeGit) FetchArgsForCall(i int) (string, int, int) {
 	fake.fetchMutex.RLock()
 	defer fake.fetchMutex.RUnlock()
 	argsForCall := fake.fetchArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeGit) FetchReturns(result1 error) {

--- a/git.go
+++ b/git.go
@@ -19,7 +19,7 @@ type Git interface {
 	Init(string) error
 	Pull(string, string, int) error
 	RevParse(string) (string, error)
-	Fetch(string, int) error
+	Fetch(string, int, int) error
 	Merge(string) error
 	Rebase(string, string) error
 	GitCryptUnlock(string) error
@@ -103,12 +103,15 @@ func (g *GitClient) RevParse(branch string) (string, error) {
 }
 
 // Fetch ...
-func (g *GitClient) Fetch(uri string, prNumber int) error {
+func (g *GitClient) Fetch(uri string, prNumber int, depth int) error {
 	endpoint, err := g.Endpoint(uri)
 	if err != nil {
 		return err
 	}
 	cmd := g.command("git", "fetch", endpoint, fmt.Sprintf("pull/%s/head", strconv.Itoa(prNumber)))
+	if depth > 0 {
+		cmd = g.command("git", "fetch", "--depth", strconv.Itoa(depth), fmt.Sprintf("pull/%s/head", strconv.Itoa(prNumber)))
+	}
 
 	// Discard output to have zero chance of logging the access token.
 	cmd.Stdout = ioutil.Discard

--- a/git.go
+++ b/git.go
@@ -17,7 +17,7 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o fakes/fake_git.go . Git
 type Git interface {
 	Init(string) error
-	Pull(string, string) error
+	Pull(string, string, int) error
 	RevParse(string) (string, error)
 	Fetch(string, int) error
 	Merge(string) error
@@ -70,12 +70,16 @@ func (g *GitClient) Init(branch string) error {
 }
 
 // Pull ...
-func (g *GitClient) Pull(uri, branch string) error {
+func (g *GitClient) Pull(uri, branch string, depth int) error {
 	endpoint, err := g.Endpoint(uri)
 	if err != nil {
 		return err
 	}
+
 	cmd := g.command("git", "pull", endpoint+".git", branch)
+	if depth > 0 {
+		cmd = g.command("git", "pull", "--depth", strconv.Itoa(depth), endpoint+".git", branch)
+	}
 
 	// Discard output to have zero chance of logging the access token.
 	cmd.Stdout = ioutil.Discard

--- a/in.go
+++ b/in.go
@@ -35,7 +35,7 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 	}
 
 	// Fetch the PR and merge the specified commit into the base
-	if err := git.Fetch(pull.Repository.URL, pull.Number); err != nil {
+	if err := git.Fetch(pull.Repository.URL, pull.Number, request.Params.GitDepth); err != nil {
 		return nil, err
 	}
 

--- a/in.go
+++ b/in.go
@@ -24,7 +24,7 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 	if err := git.Init(pull.BaseRefName); err != nil {
 		return nil, err
 	}
-	if err := git.Pull(pull.Repository.URL, pull.BaseRefName); err != nil {
+	if err := git.Pull(pull.Repository.URL, pull.BaseRefName, request.Params.GitDepth); err != nil {
 		return nil, err
 	}
 
@@ -99,6 +99,7 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 type GetParameters struct {
 	SkipDownload    bool   `json:"skip_download"`
 	IntegrationTool string `json:"integration_tool"`
+	GitDepth        int    `json:"git_depth"`
 }
 
 // GetRequest ...

--- a/in_test.go
+++ b/in_test.go
@@ -147,9 +147,10 @@ func TestGet(t *testing.T) {
 			}
 
 			if assert.Equal(t, 1, git.FetchCallCount()) {
-				url, pr := git.FetchArgsForCall(0)
+				url, pr, depth := git.FetchArgsForCall(0)
 				assert.Equal(t, tc.pullRequest.Repository.URL, url)
 				assert.Equal(t, tc.pullRequest.Number, pr)
+				assert.Equal(t, tc.parameters.GitDepth, depth)
 			}
 
 			switch tc.parameters.IntegrationTool {

--- a/in_test.go
+++ b/in_test.go
@@ -77,6 +77,22 @@ func TestGet(t *testing.T) {
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
 			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
 		},
+		{
+			description: "get supports git_depth",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				AccessToken: "oauthtoken",
+			},
+			version: resource.Version{
+				PR:            "pr1",
+				Commit:        "commit1",
+				CommittedDate: time.Time{},
+			},
+			parameters:     resource.GetParameters{GitDepth: 2},
+			pullRequest:    createTestPR(1, "master", false, false),
+			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -119,9 +135,10 @@ func TestGet(t *testing.T) {
 			}
 
 			if assert.Equal(t, 1, git.PullCallCount()) {
-				url, base := git.PullArgsForCall(0)
+				url, base, depth := git.PullArgsForCall(0)
 				assert.Equal(t, tc.pullRequest.Repository.URL, url)
 				assert.Equal(t, tc.pullRequest.BaseRefName, base)
+				assert.Equal(t, tc.parameters.GitDepth, depth)
 			}
 
 			if assert.Equal(t, 1, git.RevParseCallCount()) {


### PR DESCRIPTION
Closes #106 

Adds the `git.depth` get parameter that - when set to a positive integer - causes the resource to use `git pull --depth N` to create a shallow clone of the git repo.

I've used the `git.depth` name for two reasons:

- it matches with the name the same parameter had in `https://github.com/jtarchie/github-pullrequest-resource`
- if more git-related parameter will be added in the future, they can use the same "namespacing" `git.*`

I have very little experience with Go, so no offense taken for any comment about the style :) 