### PR TITLE
if target url is given, do not concatenate 'builds/BUILD_ID' in the url

### DIFF
--- a/github.go
+++ b/github.go
@@ -265,9 +265,7 @@ func (m *GithubClient) UpdateCommitStatus(commitRef, baseContext, statusContext,
 	build := os.Getenv("ATC_EXTERNAL_URL")
 	if targetURL != "" {
 		build = targetURL
-	}
-
-	if build != "" {
+	} else {
 		build = strings.Join([]string{build, "builds", os.Getenv("BUILD_ID")}, "/")
 	}
 


### PR DESCRIPTION
If we provide the target url, such as:

`https://ci.example.com/projects/project1/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_ID`

I think we don't need to concatenate the `builds/BUILD_ID` again, we can trust with the given target url.

What do you think?

Thank you 😄 