### PR TITLE
Clean rebase output by using oneliner

### DIFF
--- a/git.go
+++ b/git.go
@@ -126,10 +126,7 @@ func (g *GitClient) Merge(sha string) error {
 
 // Rebase ...
 func (g *GitClient) Rebase(baseRef string, headSha string) error {
-	if err := g.command("git", "checkout", headSha).Run(); err != nil {
-		return fmt.Errorf("checkout failed: %s", err)
-	}
-	if err := g.command("git", "rebase", baseRef).Run(); err != nil {
+	if err := g.command("git", "rebase", baseRef, headSha).Run(); err != nil {
 		return fmt.Errorf("rebase failed: %s", err)
 	}
 	return nil


### PR DESCRIPTION
The `git checkout <commit>` creates a somewhat noisy log output for the `get` step:

```
<...>
Note: checking out 'd63b223'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

git checkout -b <new-branch-name>
<...>
```

This PR solves this by using a one-liner to rebase the `headSha` on top of `baseRef`.