### PR TITLE
Fix fetch depth and e2e tests

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -146,14 +146,15 @@ func TestCheckE2E(t *testing.T) {
 
 func TestGetAndPutE2E(t *testing.T) {
 	tests := []struct {
-		description        string
-		source             resource.Source
-		version            resource.Version
-		getParameters      resource.GetParameters
-		putParameters      resource.PutParameters
-		versionString      string
-		metadataString     string
-		finalCommitMessage string
+		description         string
+		source              resource.Source
+		version             resource.Version
+		getParameters       resource.GetParameters
+		putParameters       resource.PutParameters
+		versionString       string
+		metadataString      string
+		expectedCommitCount int
+		expectedCommits     []string
 	}{
 		{
 			description: "get and put works",
@@ -168,11 +169,12 @@ func TestGetAndPutE2E(t *testing.T) {
 				Commit:        targetCommitID,
 				CommittedDate: time.Time{},
 			},
-			getParameters:      resource.GetParameters{},
-			putParameters:      resource.PutParameters{},
-			versionString:      `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString:     `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
-			finalCommitMessage: "Merge commit 'a5114f6ab89f4b736655642a11e8d15ce363d882'",
+			getParameters:       resource.GetParameters{},
+			putParameters:       resource.PutParameters{},
+			versionString:       `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
+			metadataString:      `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
+			expectedCommitCount: 10,
+			expectedCommits:     []string{"Merge commit 'a5114f6ab89f4b736655642a11e8d15ce363d882'"},
 		},
 		{
 			description: "get works when rebasing",
@@ -190,10 +192,11 @@ func TestGetAndPutE2E(t *testing.T) {
 			getParameters: resource.GetParameters{
 				IntegrationTool: "rebase",
 			},
-			putParameters:      resource.PutParameters{},
-			versionString:      `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString:     `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
-			finalCommitMessage: "Push 2.",
+			putParameters:       resource.PutParameters{},
+			versionString:       `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
+			metadataString:      `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
+			expectedCommitCount: 9,
+			expectedCommits:     []string{"Push 2."},
 		},
 		{
 			description: "get works with non-master bases",
@@ -208,11 +211,12 @@ func TestGetAndPutE2E(t *testing.T) {
 				Commit:        developCommitID,
 				CommittedDate: time.Time{},
 			},
-			getParameters:      resource.GetParameters{},
-			putParameters:      resource.PutParameters{},
-			versionString:      `{"pr":"6","commit":"ac771f3b69cbd63b22bbda553f827ab36150c640","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString:     `[{"name":"pr","value":"6"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/6"},{"name":"head_name","value":"test-develop-pr"},{"name":"head_sha","value":"ac771f3b69cbd63b22bbda553f827ab36150c640"},{"name":"base_name","value":"develop"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"[skip ci] Add a PR with a non-master base"},{"name":"author","value":"itsdalmo"}]`,
-			finalCommitMessage: "[skip ci] Add a PR with a non-master base", // This merge ends up being fast-forwarded
+			getParameters:       resource.GetParameters{},
+			putParameters:       resource.PutParameters{},
+			versionString:       `{"pr":"6","commit":"ac771f3b69cbd63b22bbda553f827ab36150c640","committed":"0001-01-01T00:00:00Z"}`,
+			metadataString:      `[{"name":"pr","value":"6"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/6"},{"name":"head_name","value":"test-develop-pr"},{"name":"head_sha","value":"ac771f3b69cbd63b22bbda553f827ab36150c640"},{"name":"base_name","value":"develop"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"[skip ci] Add a PR with a non-master base"},{"name":"author","value":"itsdalmo"}]`,
+			expectedCommitCount: 5,
+			expectedCommits:     []string{"[skip ci] Add a PR with a non-master base"}, // This merge ends up being fast-forwarded
 		},
 		{
 			description: "get works when ssl verification is disabled",
@@ -228,11 +232,12 @@ func TestGetAndPutE2E(t *testing.T) {
 				Commit:        targetCommitID,
 				CommittedDate: time.Time{},
 			},
-			getParameters:      resource.GetParameters{},
-			putParameters:      resource.PutParameters{},
-			versionString:      `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString:     `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
-			finalCommitMessage: "Merge commit 'a5114f6ab89f4b736655642a11e8d15ce363d882'",
+			getParameters:       resource.GetParameters{},
+			putParameters:       resource.PutParameters{},
+			versionString:       `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
+			metadataString:      `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
+			expectedCommitCount: 10,
+			expectedCommits:     []string{"Merge commit 'a5114f6ab89f4b736655642a11e8d15ce363d882'"},
 		},
 		{
 			description: "get works with git_depth",
@@ -245,11 +250,22 @@ func TestGetAndPutE2E(t *testing.T) {
 				Commit:        targetCommitID,
 				CommittedDate: time.Time{},
 			},
-			getParameters:      resource.GetParameters{GitDepth: 2},
-			putParameters:      resource.PutParameters{},
-			versionString:      `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString:     `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
-			finalCommitMessage: "Merge commit 'a5114f6ab89f4b736655642a11e8d15ce363d882'",
+			getParameters:       resource.GetParameters{GitDepth: 6},
+			putParameters:       resource.PutParameters{},
+			versionString:       `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
+			metadataString:      `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
+			expectedCommitCount: 9,
+			expectedCommits: []string{
+				"Merge commit 'a5114f6ab89f4b736655642a11e8d15ce363d882'",
+				"Push 2.",
+				"Push 1.",
+				"Add another commit to the 2nd PR to verify concourse behaviour.",
+				"Add another file to test merge commit SHA.",
+				"Add new file after creating 2nd PR.",
+				"Add another comment to 2nd pull request.",
+				"Add comment from 2nd pull request.",
+				"Add comment after creating first pull request.",
+			},
 		},
 	}
 
@@ -279,20 +295,16 @@ func TestGetAndPutE2E(t *testing.T) {
 			metadata := readTestFile(t, filepath.Join(dir, ".git", "resource", "metadata.json"))
 			assert.Equal(t, tc.metadataString, metadata)
 
-			// Ensure that commit history looks as expected
-			gitHistory := exec.Command("git", "log", "--oneline", "-n", "1", "--pretty=format:%s")
-			gitHistory.Dir = dir
+			// Check commit history
+			history := gitHistory(t, dir)
+			assert.Equal(t, tc.expectedCommitCount, len(history))
 
-			commitMessage, err := gitHistory.Output()
-			assert.NoError(t, err)
-			assert.Equal(t, tc.finalCommitMessage, string(commitMessage))
-			if tc.getParameters.GitDepth > 0 {
-				gitLog := exec.Command("git", "log", "--oneline", "--pretty=format:%s")
-				gitLog.Dir = dir
-				output, err := gitLog.Output()
-				assert.NoError(t, err)
-				commits := strings.Split(string(output), "\n")
-				assert.Equal(t, tc.getParameters.GitDepth, len(commits))
+			// Loop over the expected commits - allows us to only care about the final commit.
+			for i, expected := range tc.expectedCommits {
+				actual, ok := history[i]
+				if assert.True(t, ok) {
+					assert.Equal(t, expected, actual)
+				}
 			}
 
 			// Put
@@ -303,6 +315,24 @@ func TestGetAndPutE2E(t *testing.T) {
 			assert.Equal(t, tc.version, putOutput.Version)
 		})
 	}
+}
+
+func gitHistory(t *testing.T, directory string) map[int]string {
+	cmd := exec.Command("git", "log", "--oneline", "--pretty=format:%s")
+	cmd.Dir = directory
+
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("failed to get git historys: %s", err)
+	}
+
+	m := strings.Split(string(output), "\n")
+	h := make(map[int]string, len(m))
+	for i, s := range m {
+		h[i] = s
+	}
+
+	return h
 }
 
 func readTestFile(t *testing.T, path string) string {

--- a/git.go
+++ b/git.go
@@ -76,10 +76,11 @@ func (g *GitClient) Pull(uri, branch string, depth int) error {
 		return err
 	}
 
-	cmd := g.command("git", "pull", endpoint+".git", branch)
+	args := []string{"pull", endpoint + ".git", branch}
 	if depth > 0 {
-		cmd = g.command("git", "pull", "--depth", strconv.Itoa(depth), endpoint+".git", branch)
+		args = append(args, "--depth", strconv.Itoa(depth))
 	}
+	cmd := g.command("git", args...)
 
 	// Discard output to have zero chance of logging the access token.
 	cmd.Stdout = ioutil.Discard
@@ -108,10 +109,12 @@ func (g *GitClient) Fetch(uri string, prNumber int, depth int) error {
 	if err != nil {
 		return err
 	}
-	cmd := g.command("git", "fetch", endpoint, fmt.Sprintf("pull/%s/head", strconv.Itoa(prNumber)))
+
+	args := []string{"fetch", endpoint, fmt.Sprintf("pull/%s/head", strconv.Itoa(prNumber))}
 	if depth > 0 {
-		cmd = g.command("git", "fetch", "--depth", strconv.Itoa(depth), fmt.Sprintf("pull/%s/head", strconv.Itoa(prNumber)))
+		args = append(args, "--depth", strconv.Itoa(depth))
 	}
+	cmd := g.command("git", args...)
 
 	// Discard output to have zero chance of logging the access token.
 	cmd.Stdout = ioutil.Discard


### PR DESCRIPTION
We had a couple of issues after merging #108:
- Endpoint was not being included in the `git` command when `git_depth` was set. Fixed this, and removed the repetition to avoid future mistakes.
- E2E test for depth failed since it had the wrong expectation for the length of the git history. Rewrote the test cases to allow us to test the expected length of the git history, and the commit messages/their order.