### PR TITLE
Fix strings concatenation for status build url

### DIFF
--- a/github.go
+++ b/github.go
@@ -256,7 +256,7 @@ func (m *GithubClient) UpdateCommitStatus(commitRef, baseContext, statusContext,
 	}
 
 	if targetURL == "" {
-		targetURL = path.Join(os.Getenv("ATC_EXTERNAL_URL"), "builds", os.Getenv("BUILD_ID"))
+		targetURL = strings.Join([]string{os.Getenv("ATC_EXTERNAL_URL"), "builds", os.Getenv("BUILD_ID")}, "/")
 	}
 
 	if description == "" {


### PR DESCRIPTION
## What is going on here

Since yesterday all our PR status links became broken. Instead of https://ci.ourorg.com/builds/111 we started seeing https://github.com/ci.ourorg.com/builds/111

After some investigation, it turned out the problem is using `path.Join()` to concatenate strings, it replaces `https://ci...`  with a `http:/ci`. Sadly, Github API doesn't complain about it.