### PR TITLE
Add option to have a plain checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ generate notifications over the webhook. So if you have a repository with little
 
 #### `get`
 
-| Parameter          | Required | Example  | Description                                                              |
-|--------------------|----------|----------|--------------------------------------------------------------------------|
-| `skip_download`    | No       | `true`   | Use with `get_params` in a `put` step to do nothing on the implicit get. |
-| `integration_tool` | No       | `rebase` | The integration tool to use, `merge` or `rebase`. Defaults to `merge`.   |
-| `git_depth`        | No       | `1`      | Shallow clone the repository using the `--depth` Git option              |
+| Parameter          | Required | Example  | Description                                                                        |
+|--------------------|----------|----------|------------------------------------------------------------------------------------|
+| `skip_download`    | No       | `true`   | Use with `get_params` in a `put` step to do nothing on the implicit get.           |
+| `integration_tool` | No       | `rebase` | The integration tool to use, `merge`, `rebase` or `checkout`. Defaults to `merge`. |
+| `git_depth`        | No       | `1`      | Shallow clone the repository using the `--depth` Git option                        |
 
 Clones the base (e.g. `master` branch) at the latest commit, and merges the pull request at the specified commit
 into master. This ensures that we are both testing and setting status on the exact commit that was requested in

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -218,7 +218,15 @@ func TestGetAndPutE2E(t *testing.T) {
 			versionString:       `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
 			metadataString:      `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
 			expectedCommitCount: 7,
-			expectedCommits:     []string{"Push 2."},
+			expectedCommits: []string{
+				"Push 2.",
+				"Push 1.",
+				"Add another commit to the 2nd PR to verify concourse behaviour.",
+				"Add another comment to 2nd pull request.",
+				"Add comment from 2nd pull request.",
+				"Add comment after creating first pull request.",
+				"Initial commit",
+			},
 		},
 		{
 			description: "get works with non-master bases",

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -199,6 +199,28 @@ func TestGetAndPutE2E(t *testing.T) {
 			expectedCommits:     []string{"Push 2."},
 		},
 		{
+			description: "get works when checkout",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				V3Endpoint:  "https://api.github.com/",
+				V4Endpoint:  "https://api.github.com/graphql",
+				AccessToken: os.Getenv("GITHUB_ACCESS_TOKEN"),
+			},
+			version: resource.Version{
+				PR:            targetPullRequestID,
+				Commit:        targetCommitID,
+				CommittedDate: time.Time{},
+			},
+			getParameters: resource.GetParameters{
+				IntegrationTool: "checkout",
+			},
+			putParameters:       resource.PutParameters{},
+			versionString:       `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
+			metadataString:      `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
+			expectedCommitCount: 7,
+			expectedCommits:     []string{"Push 2."},
+		},
+		{
 			description: "get works with non-master bases",
 			source: resource.Source{
 				Repository:  "itsdalmo/test-repository",

--- a/fakes/fake_git.go
+++ b/fakes/fake_git.go
@@ -43,10 +43,11 @@ type FakeGit struct {
 	initReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CheckoutStub        func(string) error
+	CheckoutStub        func(string, string) error
 	checkoutMutex       sync.RWMutex
 	checkoutArgsForCall []struct {
 		arg1 string
+		arg2 string
 	}
 	checkoutReturns struct {
 		result1 error
@@ -289,16 +290,17 @@ func (fake *FakeGit) InitReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeGit) Checkout(arg1 string) error {
+func (fake *FakeGit) Checkout(arg1 string, arg2 string) error {
 	fake.checkoutMutex.Lock()
 	ret, specificReturn := fake.checkoutReturnsOnCall[len(fake.checkoutArgsForCall)]
 	fake.checkoutArgsForCall = append(fake.checkoutArgsForCall, struct {
 		arg1 string
-	}{arg1})
+		arg2 string
+	}{arg1, arg2})
 	fake.recordInvocation("CheckOut", []interface{}{arg1})
 	fake.checkoutMutex.Unlock()
 	if fake.CheckoutStub != nil {
-		return fake.CheckoutStub(arg1)
+		return fake.CheckoutStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -313,17 +315,17 @@ func (fake *FakeGit) CheckoutCallCount() int {
 	return len(fake.checkoutArgsForCall)
 }
 
-func (fake *FakeGit) CheckoutCalls(stub func(string) error) {
+func (fake *FakeGit) CheckoutCalls(stub func(string, string) error) {
 	fake.checkoutMutex.Lock()
 	defer fake.checkoutMutex.Unlock()
 	fake.CheckoutStub = stub
 }
 
-func (fake *FakeGit) CheckoutArgsForCall(i int) string {
+func (fake *FakeGit) CheckoutArgsForCall(i int) (string, string) {
 	fake.checkoutMutex.RLock()
 	defer fake.checkoutMutex.RUnlock()
 	argsForCall := fake.checkoutArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeGit) CheckoutReturns(result1 error) {

--- a/fakes/fake_git.go
+++ b/fakes/fake_git.go
@@ -8,6 +8,18 @@ import (
 )
 
 type FakeGit struct {
+	CheckoutStub        func(string, string) error
+	checkoutMutex       sync.RWMutex
+	checkoutArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	checkoutReturns struct {
+		result1 error
+	}
+	checkoutReturnsOnCall map[int]struct {
+		result1 error
+	}
 	FetchStub        func(string, int, int) error
 	fetchMutex       sync.RWMutex
 	fetchArgsForCall []struct {
@@ -41,18 +53,6 @@ type FakeGit struct {
 		result1 error
 	}
 	initReturnsOnCall map[int]struct {
-		result1 error
-	}
-	CheckoutStub        func(string, string) error
-	checkoutMutex       sync.RWMutex
-	checkoutArgsForCall []struct {
-		arg1 string
-		arg2 string
-	}
-	checkoutReturns struct {
-		result1 error
-	}
-	checkoutReturnsOnCall map[int]struct {
 		result1 error
 	}
 	MergeStub        func(string) error
@@ -106,6 +106,67 @@ type FakeGit struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeGit) Checkout(arg1 string, arg2 string) error {
+	fake.checkoutMutex.Lock()
+	ret, specificReturn := fake.checkoutReturnsOnCall[len(fake.checkoutArgsForCall)]
+	fake.checkoutArgsForCall = append(fake.checkoutArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("Checkout", []interface{}{arg1, arg2})
+	fake.checkoutMutex.Unlock()
+	if fake.CheckoutStub != nil {
+		return fake.CheckoutStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.checkoutReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeGit) CheckoutCallCount() int {
+	fake.checkoutMutex.RLock()
+	defer fake.checkoutMutex.RUnlock()
+	return len(fake.checkoutArgsForCall)
+}
+
+func (fake *FakeGit) CheckoutCalls(stub func(string, string) error) {
+	fake.checkoutMutex.Lock()
+	defer fake.checkoutMutex.Unlock()
+	fake.CheckoutStub = stub
+}
+
+func (fake *FakeGit) CheckoutArgsForCall(i int) (string, string) {
+	fake.checkoutMutex.RLock()
+	defer fake.checkoutMutex.RUnlock()
+	argsForCall := fake.checkoutArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeGit) CheckoutReturns(result1 error) {
+	fake.checkoutMutex.Lock()
+	defer fake.checkoutMutex.Unlock()
+	fake.CheckoutStub = nil
+	fake.checkoutReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeGit) CheckoutReturnsOnCall(i int, result1 error) {
+	fake.checkoutMutex.Lock()
+	defer fake.checkoutMutex.Unlock()
+	fake.CheckoutStub = nil
+	if fake.checkoutReturnsOnCall == nil {
+		fake.checkoutReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkoutReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeGit) Fetch(arg1 string, arg2 int, arg3 int) error {
@@ -286,67 +347,6 @@ func (fake *FakeGit) InitReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.initReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeGit) Checkout(arg1 string, arg2 string) error {
-	fake.checkoutMutex.Lock()
-	ret, specificReturn := fake.checkoutReturnsOnCall[len(fake.checkoutArgsForCall)]
-	fake.checkoutArgsForCall = append(fake.checkoutArgsForCall, struct {
-		arg1 string
-		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("CheckOut", []interface{}{arg1})
-	fake.checkoutMutex.Unlock()
-	if fake.CheckoutStub != nil {
-		return fake.CheckoutStub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.checkoutReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeGit) CheckoutCallCount() int {
-	fake.checkoutMutex.RLock()
-	defer fake.checkoutMutex.RUnlock()
-	return len(fake.checkoutArgsForCall)
-}
-
-func (fake *FakeGit) CheckoutCalls(stub func(string, string) error) {
-	fake.checkoutMutex.Lock()
-	defer fake.checkoutMutex.Unlock()
-	fake.CheckoutStub = stub
-}
-
-func (fake *FakeGit) CheckoutArgsForCall(i int) (string, string) {
-	fake.checkoutMutex.RLock()
-	defer fake.checkoutMutex.RUnlock()
-	argsForCall := fake.checkoutArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeGit) CheckoutReturns(result1 error) {
-	fake.checkoutMutex.Lock()
-	defer fake.checkoutMutex.Unlock()
-	fake.CheckoutStub = nil
-	fake.checkoutReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeGit) CheckoutReturnsOnCall(i int, result1 error) {
-	fake.checkoutMutex.Lock()
-	defer fake.checkoutMutex.Unlock()
-	fake.CheckoutStub = nil
-	if fake.checkoutReturnsOnCall == nil {
-		fake.checkoutReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.checkoutReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -600,6 +600,8 @@ func (fake *FakeGit) RevParseReturnsOnCall(i int, result1 string, result2 error)
 func (fake *FakeGit) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.checkoutMutex.RLock()
+	defer fake.checkoutMutex.RUnlock()
 	fake.fetchMutex.RLock()
 	defer fake.fetchMutex.RUnlock()
 	fake.gitCryptUnlockMutex.RLock()

--- a/fakes/fake_git.go
+++ b/fakes/fake_git.go
@@ -43,6 +43,17 @@ type FakeGit struct {
 	initReturnsOnCall map[int]struct {
 		result1 error
 	}
+	CheckoutStub        func(string) error
+	checkoutMutex       sync.RWMutex
+	checkoutArgsForCall []struct {
+		arg1 string
+	}
+	checkoutReturns struct {
+		result1 error
+	}
+	checkoutReturnsOnCall map[int]struct {
+		result1 error
+	}
 	MergeStub        func(string) error
 	mergeMutex       sync.RWMutex
 	mergeArgsForCall []struct {
@@ -274,6 +285,66 @@ func (fake *FakeGit) InitReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.initReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeGit) Checkout(arg1 string) error {
+	fake.checkoutMutex.Lock()
+	ret, specificReturn := fake.checkoutReturnsOnCall[len(fake.checkoutArgsForCall)]
+	fake.checkoutArgsForCall = append(fake.checkoutArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("CheckOut", []interface{}{arg1})
+	fake.checkoutMutex.Unlock()
+	if fake.CheckoutStub != nil {
+		return fake.CheckoutStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.checkoutReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeGit) CheckoutCallCount() int {
+	fake.checkoutMutex.RLock()
+	defer fake.checkoutMutex.RUnlock()
+	return len(fake.checkoutArgsForCall)
+}
+
+func (fake *FakeGit) CheckoutCalls(stub func(string) error) {
+	fake.checkoutMutex.Lock()
+	defer fake.checkoutMutex.Unlock()
+	fake.CheckoutStub = stub
+}
+
+func (fake *FakeGit) CheckoutArgsForCall(i int) string {
+	fake.checkoutMutex.RLock()
+	defer fake.checkoutMutex.RUnlock()
+	argsForCall := fake.checkoutArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeGit) CheckoutReturns(result1 error) {
+	fake.checkoutMutex.Lock()
+	defer fake.checkoutMutex.Unlock()
+	fake.CheckoutStub = nil
+	fake.checkoutReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeGit) CheckoutReturnsOnCall(i int, result1 error) {
+	fake.checkoutMutex.Lock()
+	defer fake.checkoutMutex.Unlock()
+	fake.CheckoutStub = nil
+	if fake.checkoutReturnsOnCall == nil {
+		fake.checkoutReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkoutReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/git.go
+++ b/git.go
@@ -128,7 +128,7 @@ func (g *GitClient) Fetch(uri string, prNumber int, depth int) error {
 }
 
 // CheckOut
-func (g *GitClient) Checkout(branch string, sha string) error {
+func (g *GitClient) Checkout(branch, sha string) error {
 	if err := g.command("git", "checkout", "-b", branch, sha).Run(); err != nil {
 		return fmt.Errorf("checkout failed: %s", err)
 	}

--- a/git.go
+++ b/git.go
@@ -20,6 +20,7 @@ type Git interface {
 	Pull(string, string, int) error
 	RevParse(string) (string, error)
 	Fetch(string, int, int) error
+	Checkout(string) error
 	Merge(string) error
 	Rebase(string, string) error
 	GitCryptUnlock(string) error
@@ -123,6 +124,15 @@ func (g *GitClient) Fetch(uri string, prNumber int, depth int) error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("fetch failed: %s", err)
 	}
+	return nil
+}
+
+// CheckOut
+func (g *GitClient) Checkout(branch string) error {
+	if err := g.command("git", "checkout", branch).Run(); err != nil {
+		return fmt.Errorf("checkout failed: %s", err)
+	}
+
 	return nil
 }
 

--- a/git.go
+++ b/git.go
@@ -20,7 +20,7 @@ type Git interface {
 	Pull(string, string, int) error
 	RevParse(string) (string, error)
 	Fetch(string, int, int) error
-	Checkout(string) error
+	Checkout(string, string) error
 	Merge(string) error
 	Rebase(string, string) error
 	GitCryptUnlock(string) error
@@ -128,8 +128,8 @@ func (g *GitClient) Fetch(uri string, prNumber int, depth int) error {
 }
 
 // CheckOut
-func (g *GitClient) Checkout(branch string) error {
-	if err := g.command("git", "checkout", branch).Run(); err != nil {
+func (g *GitClient) Checkout(branch string, sha string) error {
+	if err := g.command("git", "checkout", "-b", branch, sha).Run(); err != nil {
 		return fmt.Errorf("checkout failed: %s", err)
 	}
 

--- a/in.go
+++ b/in.go
@@ -48,6 +48,10 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 		if err := git.Merge(pull.Tip.OID); err != nil {
 			return nil, err
 		}
+	case "checkout":
+		if err := git.Checkout(pull.HeadRefName); err != nil {
+			return nil, err
+		}
 	default:
 		return nil, fmt.Errorf("invalid integration tool specified: %s", tool)
 	}

--- a/in.go
+++ b/in.go
@@ -49,7 +49,7 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 			return nil, err
 		}
 	case "checkout":
-		if err := git.Checkout(pull.HeadRefName); err != nil {
+		if err := git.Checkout(pull.HeadRefName, pull.Tip.OID); err != nil {
 			return nil, err
 		}
 	default:

--- a/in_test.go
+++ b/in_test.go
@@ -78,6 +78,24 @@ func TestGet(t *testing.T) {
 			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
 		},
 		{
+			description: "get supports checkout",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				AccessToken: "oauthtoken",
+			},
+			version: resource.Version{
+				PR:            "pr1",
+				Commit:        "commit1",
+				CommittedDate: time.Time{},
+			},
+			parameters: resource.GetParameters{
+				IntegrationTool: "checkout",
+			},
+			pullRequest:    createTestPR(1, "master", false, false),
+			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
+		},
+		{
 			description: "get supports git_depth",
 			source: resource.Source{
 				Repository:  "itsdalmo/test-repository",
@@ -159,6 +177,11 @@ func TestGet(t *testing.T) {
 					branch, tip := git.RebaseArgsForCall(0)
 					assert.Equal(t, tc.pullRequest.BaseRefName, branch)
 					assert.Equal(t, tc.pullRequest.Tip.OID, tip)
+				}
+			case "checkout":
+				if assert.Equal(t, 1, git.CheckoutCallCount()) {
+					branch := git.CheckoutArgsForCall(0)
+					assert.Equal(t, tc.pullRequest.HeadRefName, branch)
 				}
 			default:
 				if assert.Equal(t, 1, git.MergeCallCount()) {

--- a/in_test.go
+++ b/in_test.go
@@ -180,8 +180,9 @@ func TestGet(t *testing.T) {
 				}
 			case "checkout":
 				if assert.Equal(t, 1, git.CheckoutCallCount()) {
-					branch := git.CheckoutArgsForCall(0)
+					branch, sha := git.CheckoutArgsForCall(0)
 					assert.Equal(t, tc.pullRequest.HeadRefName, branch)
+					assert.Equal(t, tc.pullRequest.Tip.OID, sha)
 				}
 			default:
 				if assert.Equal(t, 1, git.MergeCallCount()) {


### PR DESCRIPTION
resolves #115 

Context are pretty much included in #115 .
Just thought that `checkout` would make more sense than `none` as an option for the `integrationTool`.