### PR TITLE
Explode metadata.json into individual files

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -325,6 +325,22 @@ func TestGetAndPutE2E(t *testing.T) {
 			metadata := readTestFile(t, filepath.Join(dir, ".git", "resource", "metadata.json"))
 			assert.Equal(t, tc.metadataString, metadata)
 
+			individual_files := map[string]string {
+				"pr": "4",
+				"url": "https://github.com/itsdalmo/test-repository/pull/4",
+				"head_name": "my_second_pull",
+				"head_sha": "a5114f6ab89f4b736655642a11e8d15ce363d882",
+				"base_name": "master",
+				"base_sha": "93eeeedb8a16e6662062d1eca5655108977cc59a",
+				"message": "Push 2.",
+				"author": "itsdalmo",
+			}
+			for filename, expected_content := range individual_files {
+				actual_content := readTestFile(t, filepath.Join(dir, ".git", "resource", filename))
+				assert.Equal(t, actual_content, expected_content)
+			}
+
+
 			// Check commit history
 			history := gitHistory(t, dir)
 			assert.Equal(t, tc.expectedCommitCount, len(history))

--- a/in.go
+++ b/in.go
@@ -93,6 +93,14 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 		return nil, fmt.Errorf("failed to write metadata: %s", err)
 	}
 
+	for _, d := range metadata {
+		filename := d.Name
+		content := []byte(d.Value)
+		if err := ioutil.WriteFile(filepath.Join(path, filename), content, 0644); err != nil {
+			return nil, fmt.Errorf("failed to write metadata file %s: %s", filename, err)
+		}
+	}
+
 	return &GetResponse{
 		Version:  request.Version,
 		Metadata: metadata,

--- a/in_test.go
+++ b/in_test.go
@@ -137,6 +137,22 @@ func TestGet(t *testing.T) {
 
 				metadata := readTestFile(t, filepath.Join(dir, ".git", "resource", "metadata.json"))
 				assert.Equal(t, tc.metadataString, metadata)
+
+				// Verify individual files
+				individual_files := map[string]string {
+					"pr": "1",
+					"url": "pr1 url",
+					"head_name": "pr1",
+					"head_sha": "oid1",
+					"base_name": "master",
+					"base_sha": "sha",
+					"message": "commit message1",
+					"author": "login1",
+				}
+				for filename, expected_content := range individual_files {
+					actual_content := readTestFile(t, filepath.Join(dir, ".git", "resource", filename))
+					assert.Equal(t, actual_content, expected_content)
+				}
 			}
 
 			// Validate Github calls


### PR DESCRIPTION
The GitHub PR resource type by jtarchie [1] created files that
contained the PR information [2].  Each file contained one piece of
information (e.g., the git branch name or the author).  This format
was convenient since many resource types are configured by passing the
name of a file that contains the option's value.  For example, the
`tag_file` option of the Docker Image resource type accepts the name
of a file whose content is the desired tag [3].

The telia-oss GitHub resource type puts all the PR information in a
single file, metadata.json.  To extract data from this file, it's
necessary to create a new task.

This commit modifies `in.go` so that each individual PR information is
also written into its own file.  For example, `.git/resource/head_name`
contains the name of the git branch.  It helps make some tasks -- such
as using the git branch name as the Docker tag -- as simple as they
were when using the jtarchie resource type.

[1]: https://github.com/jtarchie/github-pullrequest-resource
[2]: https://github.com/jtarchie/github-pullrequest-resource#additional-files-populated
[3]: https://github.com/concourse/docker-image-resource#out-push-an-image-or-build-and-push-a-dockerfile