### PR TITLE
Fix metadata files e2e test

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -153,6 +153,7 @@ func TestGetAndPutE2E(t *testing.T) {
 		putParameters       resource.PutParameters
 		versionString       string
 		metadataString      string
+		metadataFiles       map[string]string
 		expectedCommitCount int
 		expectedCommits     []string
 	}{
@@ -169,10 +170,20 @@ func TestGetAndPutE2E(t *testing.T) {
 				Commit:        targetCommitID,
 				CommittedDate: time.Time{},
 			},
-			getParameters:       resource.GetParameters{},
-			putParameters:       resource.PutParameters{},
-			versionString:       `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString:      `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
+			getParameters:  resource.GetParameters{},
+			putParameters:  resource.PutParameters{},
+			versionString:  `{"pr":"4","commit":"a5114f6ab89f4b736655642a11e8d15ce363d882","committed":"0001-01-01T00:00:00Z"}`,
+			metadataString: `[{"name":"pr","value":"4"},{"name":"url","value":"https://github.com/itsdalmo/test-repository/pull/4"},{"name":"head_name","value":"my_second_pull"},{"name":"head_sha","value":"a5114f6ab89f4b736655642a11e8d15ce363d882"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"93eeeedb8a16e6662062d1eca5655108977cc59a"},{"name":"message","value":"Push 2."},{"name":"author","value":"itsdalmo"}]`,
+			metadataFiles: map[string]string{
+				"pr":        "4",
+				"url":       "https://github.com/itsdalmo/test-repository/pull/4",
+				"head_name": "my_second_pull",
+				"head_sha":  "a5114f6ab89f4b736655642a11e8d15ce363d882",
+				"base_name": "master",
+				"base_sha":  "93eeeedb8a16e6662062d1eca5655108977cc59a",
+				"message":   "Push 2.",
+				"author":    "itsdalmo",
+			},
 			expectedCommitCount: 10,
 			expectedCommits:     []string{"Merge commit 'a5114f6ab89f4b736655642a11e8d15ce363d882'"},
 		},
@@ -325,18 +336,7 @@ func TestGetAndPutE2E(t *testing.T) {
 			metadata := readTestFile(t, filepath.Join(dir, ".git", "resource", "metadata.json"))
 			assert.Equal(t, tc.metadataString, metadata)
 
-			files := map[string]string{
-				"pr":        "4",
-				"url":       "https://github.com/itsdalmo/test-repository/pull/4",
-				"head_name": "my_second_pull",
-				"head_sha":  "a5114f6ab89f4b736655642a11e8d15ce363d882",
-				"base_name": "master",
-				"base_sha":  "93eeeedb8a16e6662062d1eca5655108977cc59a",
-				"message":   "Push 2.",
-				"author":    "itsdalmo",
-			}
-
-			for filename, expected := range files {
+			for filename, expected := range tc.metadataFiles {
 				actual := readTestFile(t, filepath.Join(dir, ".git", "resource", filename))
 				assert.Equal(t, expected, actual)
 			}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -338,7 +338,7 @@ func TestGetAndPutE2E(t *testing.T) {
 
 			for filename, expected := range files {
 				actual := readTestFile(t, filepath.Join(dir, ".git", "resource", filename))
-				assert.Equal(t, actual, expected)
+				assert.Equal(t, expected, actual)
 			}
 
 			// Check commit history

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -325,21 +325,21 @@ func TestGetAndPutE2E(t *testing.T) {
 			metadata := readTestFile(t, filepath.Join(dir, ".git", "resource", "metadata.json"))
 			assert.Equal(t, tc.metadataString, metadata)
 
-			individual_files := map[string]string {
-				"pr": "4",
-				"url": "https://github.com/itsdalmo/test-repository/pull/4",
+			files := map[string]string{
+				"pr":        "4",
+				"url":       "https://github.com/itsdalmo/test-repository/pull/4",
 				"head_name": "my_second_pull",
-				"head_sha": "a5114f6ab89f4b736655642a11e8d15ce363d882",
+				"head_sha":  "a5114f6ab89f4b736655642a11e8d15ce363d882",
 				"base_name": "master",
-				"base_sha": "93eeeedb8a16e6662062d1eca5655108977cc59a",
-				"message": "Push 2.",
-				"author": "itsdalmo",
-			}
-			for filename, expected_content := range individual_files {
-				actual_content := readTestFile(t, filepath.Join(dir, ".git", "resource", filename))
-				assert.Equal(t, actual_content, expected_content)
+				"base_sha":  "93eeeedb8a16e6662062d1eca5655108977cc59a",
+				"message":   "Push 2.",
+				"author":    "itsdalmo",
 			}
 
+			for filename, expected := range files {
+				actual := readTestFile(t, filepath.Join(dir, ".git", "resource", filename))
+				assert.Equal(t, actual, expected)
+			}
 
 			// Check commit history
 			history := gitHistory(t, dir)

--- a/in_test.go
+++ b/in_test.go
@@ -139,19 +139,20 @@ func TestGet(t *testing.T) {
 				assert.Equal(t, tc.metadataString, metadata)
 
 				// Verify individual files
-				individual_files := map[string]string {
-					"pr": "1",
-					"url": "pr1 url",
+				files := map[string]string{
+					"pr":        "1",
+					"url":       "pr1 url",
 					"head_name": "pr1",
-					"head_sha": "oid1",
+					"head_sha":  "oid1",
 					"base_name": "master",
-					"base_sha": "sha",
-					"message": "commit message1",
-					"author": "login1",
+					"base_sha":  "sha",
+					"message":   "commit message1",
+					"author":    "login1",
 				}
-				for filename, expected_content := range individual_files {
-					actual_content := readTestFile(t, filepath.Join(dir, ".git", "resource", filename))
-					assert.Equal(t, actual_content, expected_content)
+
+				for filename, expected := range files {
+					actual := readTestFile(t, filepath.Join(dir, ".git", "resource", filename))
+					assert.Equal(t, actual, expected)
 				}
 			}
 

--- a/in_test.go
+++ b/in_test.go
@@ -152,7 +152,7 @@ func TestGet(t *testing.T) {
 
 				for filename, expected := range files {
 					actual := readTestFile(t, filepath.Join(dir, ".git", "resource", filename))
-					assert.Equal(t, actual, expected)
+					assert.Equal(t, expected, actual)
 				}
 			}
 


### PR DESCRIPTION
This fixes the e2e tests for individual metadata files. I think a single test is enough since the content will be identical to `metadata.json`, which is checked in every test case. Also I did not notice the `snake_case` when merging #122 😅 