### PR TITLE
Add more metadata for better fork support

### DIFF
--- a/in.go
+++ b/in.go
@@ -72,6 +72,8 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 	metadata.Add("base_sha", baseSHA)
 	metadata.Add("message", pull.Tip.Message)
 	metadata.Add("author", pull.Tip.Author.User.Login)
+	metadata.Add("repository_url", pull.Repository.URL)
+	metadata.Add("is_cross_repository", strconv.FormatBool(pull.IsCrossRepository))
 
 	// Write version and metadata for reuse in PUT
 	path := filepath.Join(outputDir, ".git", "resource")

--- a/in.go
+++ b/in.go
@@ -74,6 +74,7 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 	metadata.Add("author", pull.Tip.Author.User.Login)
 	metadata.Add("repository_url", pull.Repository.URL)
 	metadata.Add("is_cross_repository", strconv.FormatBool(pull.IsCrossRepository))
+	metadata.Add("head_repository_url", pull.HeadRepository.URL)
 
 	// Write version and metadata for reuse in PUT
 	path := filepath.Join(outputDir, ".git", "resource")

--- a/in_test.go
+++ b/in_test.go
@@ -42,7 +42,7 @@ func TestGet(t *testing.T) {
 			parameters:     resource.GetParameters{},
 			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
 		},
 		{
 			description: "get supports unlocking with git crypt",
@@ -59,7 +59,7 @@ func TestGet(t *testing.T) {
 			parameters:     resource.GetParameters{},
 			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
 		},
 		{
 			description: "get supports rebasing",
@@ -77,7 +77,7 @@ func TestGet(t *testing.T) {
 			},
 			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
 		},
 		{
 			description: "get supports checkout",
@@ -95,7 +95,7 @@ func TestGet(t *testing.T) {
 			},
 			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
 		},
 		{
 			description: "get supports git_depth",
@@ -113,7 +113,7 @@ func TestGet(t *testing.T) {
 			},
 			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
 		},
 		{
 			description: "get supports list_changed_files",
@@ -139,7 +139,7 @@ func TestGet(t *testing.T) {
 				},
 			},
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
 			filesString:    "README.md\nOther.md\n",
 		},
 	}

--- a/in_test.go
+++ b/in_test.go
@@ -42,7 +42,7 @@ func TestGet(t *testing.T) {
 			parameters:     resource.GetParameters{},
 			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":"repo1 url"}]`,
 		},
 		{
 			description: "get supports unlocking with git crypt",
@@ -59,7 +59,7 @@ func TestGet(t *testing.T) {
 			parameters:     resource.GetParameters{},
 			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":"repo1 url"}]`,
 		},
 		{
 			description: "get supports rebasing",
@@ -77,7 +77,7 @@ func TestGet(t *testing.T) {
 			},
 			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":"repo1 url"}]`,
 		},
 		{
 			description: "get supports checkout",
@@ -95,7 +95,7 @@ func TestGet(t *testing.T) {
 			},
 			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":"repo1 url"}]`,
 		},
 		{
 			description: "get supports git_depth",
@@ -113,7 +113,7 @@ func TestGet(t *testing.T) {
 			},
 			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":"repo1 url"}]`,
 		},
 		{
 			description: "get supports list_changed_files",
@@ -139,7 +139,7 @@ func TestGet(t *testing.T) {
 				},
 			},
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":""}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"repository_url","value":"repo1 url"},{"name":"is_cross_repository","value":"false"},{"name":"head_repository_url","value":"repo1 url"}]`,
 			filesString:    "README.md\nOther.md\n",
 		},
 	}
@@ -323,6 +323,14 @@ func createTestPR(
 		labelObjects = append(labelObjects, lObject)
 	}
 
+	url := fmt.Sprintf("repo%s url", n)
+	var headUrl string
+	if isCrossRepo {
+		headUrl = fmt.Sprintf("repo-fork%s url", n)
+	} else {
+		headUrl = url
+	}
+
 	return &resource.PullRequest{
 		PullRequestObject: resource.PullRequestObject{
 			ID:          fmt.Sprintf("pr%s", n),
@@ -332,7 +340,10 @@ func createTestPR(
 			BaseRefName: baseName,
 			HeadRefName: fmt.Sprintf("pr%s", n),
 			Repository: struct{ URL string }{
-				URL: fmt.Sprintf("repo%s url", n),
+				URL: url,
+			},
+			HeadRepository: struct{ URL string }{
+				URL: headUrl,
 			},
 			IsCrossRepository: isCrossRepo,
 		},

--- a/models.go
+++ b/models.go
@@ -92,6 +92,9 @@ type PullRequestObject struct {
 	Repository  struct {
 		URL string
 	}
+	HeadRepository struct {
+		URL string
+	}
 	IsCrossRepository bool
 }
 


### PR DESCRIPTION
This PR adds a few fields to `metadata.json` which are useful when observing pull requests across different repos.

Please squash this PR