### PR TITLE
Add preformat_comment_file put parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `disable_ci_skip`           | No       | `true`                           | Disable ability to skip builds with `[ci skip]` and `[skip ci]` in commit message or pull request title.                                                                                                                                                                                   |
 | `skip_ssl_verification`     | No       | `true`                           | Disable SSL/TLS certificate validation on git and API clients. Use with care!                                                                                                                                                                                                              |
 | `disable_forks`             | No       | `true`                           | Disable triggering of the resource if the pull request's fork repository is different to the configured repository.                                                                                                                                                                        |
-| `required_review_approvals` | No       | `2`                              | Disable triggering of the resource if the pull request does not have at least `X` approved review(s).                                                                                                                                                                                      | 
+| `required_review_approvals` | No       | `2`                              | Disable triggering of the resource if the pull request does not have at least `X` approved review(s).                                                                                                                                                                                      |
 | `git_crypt_key`             | No       | `AEdJVENSWVBUS0VZAAAAA...`       | Base64 encoded git-crypt key. Setting this will unlock / decrypt the repository with git-crypt. To get the key simply execute `git-crypt export-key -- - | base64` in an encrypted repository.                                                                                             |
 | `base_branch`               | No       | `master`                         | Name of a branch. The pipeline will only trigger on pull requests against the specified branch.                                                                                                                                                                                            |
 | `labels`                    | No       | `["bug", "enhancement"]`         | The labels on the PR. The pipeline will only trigger on pull requests having at least one of the specified labels.                                                                                                                                                                         |
@@ -80,7 +80,7 @@ requested version and the metadata emitted by `get` are available to your tasks 
 - `.git/resource/changed_files` (if enabled by `list_changed_files`)
 
 The information in `metadata.json` is also available as individual files in the `.git/resource` directory, e.g. the `base_sha`
-is available as `.git/resource/base_sha`. For a complete list of available (individual) metadata files, please check the code 
+is available as `.git/resource/base_sha`. For a complete list of available (individual) metadata files, please check the code
 [here](https://github.com/telia-oss/github-pr-resource/blob/master/in.go#L66).
 
 When specifying `skip_download` the pull request volume mounted to subsequent tasks will be empty, which is a problem
@@ -106,18 +106,19 @@ empty commit to the PR*.
 
 #### `put`
 
-| Parameter      | Required | Example                             | Description                                                                                                       |
-|----------------|----------|-------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| `path`              | Yes      | `pull-request`                      | The name given to the resource in a GET step.                                                                     |
-| `status`            | No       | `SUCCESS`                           | Set a status on a commit. One of `SUCCESS`, `PENDING`, `FAILURE` and `ERROR`.                                     |
-| `base_context`      | No       | `concourse-ci`                      | Base context (prefix) used for the status context. Defaults to `concourse-ci`.                                    |
-| `context`           | No       | `unit-test`                         | A context to use for the status, which is prefixed by `base_context`. Defaults to `status`.                       |
-| `comment`           | No       | `hello world!`                      | A comment to add to the pull request.                                                                             |
-| `comment_file`      | No       | `my-output/comment.txt`             | Path to file containing a comment to add to the pull request (e.g. output of `terraform plan`).                   |
-| `target_url`        | No       | `$ATC_DEFAULT_URL/builds/$BUILD_ID` | The target URL for the status, where users are sent when clicking details (defaults to the Concourse build page). |
-| `description`       | No       | `Concourse CI build failed`         | The description status on the specified pull request.                                                             |
-| `description_file`  | No       | `my-output/description.txt`         | Path to file containing the description status to add to the pull request                                         |
-| `delete_previous_comments` | No       | `true`         |  Boolean. Previous comments made on the pull request by this resource will be deleted before making the new comment. Useful for removing outdated information. |
+| Parameter                  | Required   | Example                               | Description                                                                                                                                                   |
+| -------------------------- | ---------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------                                           |
+| `path`                     | Yes        | `pull-request`                        | The name given to the resource in a GET step.                                                                                                                 |
+| `status`                   | No         | `SUCCESS`                             | Set a status on a commit. One of `SUCCESS`, `PENDING`, `FAILURE` and `ERROR`.                                                                                 |
+| `base_context`             | No         | `concourse-ci`                        | Base context (prefix) used for the status context. Defaults to `concourse-ci`.                                                                                |
+| `context`                  | No         | `unit-test`                           | A context to use for the status, which is prefixed by `base_context`. Defaults to `status`.                                                                   |
+| `comment`                  | No         | `hello world!`                        | A comment to add to the pull request.                                                                                                                         |
+| `comment_file`             | No         | `my-output/comment.txt`               | Path to file containing a comment to add to the pull request (e.g. output of `terraform plan`).                                                               |
+| `preformat_comment_file`   | No         | `true`                                | Post the comment file as preformatted text.
+| `target_url`               | No         | `$ATC_DEFAULT_URL/builds/$BUILD_ID`   | The target URL for the status, where users are sent when clicking details (defaults to the Concourse build page).                                             |
+| `description`              | No         | `Concourse CI build failed`           | The description status on the specified pull request.                                                                                                         |
+| `description_file`         | No         | `my-output/description.txt`           | Path to file containing the description status to add to the pull request                                                                                     |
+| `delete_previous_comments` | No         | `true`                                | Boolean. Previous comments made on the pull request by this resource will be deleted before making the new comment. Useful for removing outdated information. |
 
 Note that `comment`, `comment_file` and `target_url` will all expand environment variables, so in the examples above `$ATC_DEFAULT_URL` will be replaced by the public URL of the Concourse ATCs.
 See https://concourse-ci.org/implementing-resource-types.html#resource-metadata for more details about metadata that is available via environment variables.

--- a/out.go
+++ b/out.go
@@ -78,6 +78,9 @@ func Put(request PutRequest, manager Github, inputDir string) (*PutResponse, err
 		}
 		comment := string(content)
 		if comment != "" {
+			if p.PreformatCommentFile {
+				comment = fmt.Sprintf("```\n%s\n```", comment)
+			}
 			err = manager.PostComment(version.PR, os.ExpandEnv(comment))
 			if err != nil {
 				return nil, fmt.Errorf("failed to post comment: %s", err)
@@ -113,6 +116,7 @@ type PutParameters struct {
 	Description            string `json:"description"`
 	Status                 string `json:"status"`
 	CommentFile            string `json:"comment_file"`
+	PreformatCommentFile   bool   `json:"preformat_comment_file"`
 	Comment                string `json:"comment"`
 	DeletePreviousComments bool   `json:"delete_previous_comments"`
 }


### PR DESCRIPTION
Comments like logs or output of `terraform plan` look a bit nicer when they are wrapped in "```".
This PR adds the `preformat_comment_file` `Put` option that enables such behavior.