### PR TITLE
Add query cost test

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,25 +180,17 @@ jobs:
 ## Costs
 
 The Github API(s) have a rate limit of 5000 requests per hour (per user). For the V3 API this essentially
-translates to 5000 requests, whereas for the V4 API (GraphQL)  the calculation is a bit more involved:
+translates to 5000 requests, whereas for the V4 API (GraphQL)  the calculation is more involved:
 https://developer.github.com/v4/guides/resource-limitations/#calculating-a-rate-limit-score-before-running-the-call
 
-Ref the above, this resource will incur the following (estimated) costs:
-- `check`:
-  - List the last 100 (open) PRs: 100
-  - Get the last commit from the 100 PRs: 100
-  - Get the first 100 labels from each PR: 100x100 = 10000
-  - Total: 10200/100 = 102. This is the _max_ if you have 100 open PRs and 100 labels on each PR.
+Ref the above, here are some examples of running `check` against large repositories and the cost of doing so:
+- [concourse/concourse](https://github.com/concourse/concourse): 51 open pull requests at the time of testing. Cost 2.
+- [torvalds/linux](https://github.com/torvalds/linux): 305 open pull requests. Cost 8.
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes): 1072 open pull requests, and heavy use of leables. Cost: 22.
+
+For the other two operations the costing is a bit easier:
 - `get`: Fixed cost of 1. Fetches the pull request at the given commit.
 - `put`: Uses the V3 API and has a min cost of 1, +1 for each of `status`, `comment` and `comment_file` etc.
-
-E.g., typical use for a repository with 125 open pull requests, with on average 3 labels per PR will incur the following costs for every commit:
-
-- `check`: List PRs: 2, Latest commit: 125, Lables: 125x3=375. The total cost is then (2+125+375)/100=5.
-- `in`: 1 (fetch the pull request at the given commit ref)
-- `out`: 1 (set status on the commit)
-
-With a rate limit of 5000 per hour, it could handle ~700 commits between all of the 125 open pull requests in the span of that hour.
 
 ## Migrating
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ https://developer.github.com/v4/guides/resource-limitations/#calculating-a-rate-
 Ref the above, here are some examples of running `check` against large repositories and the cost of doing so:
 - [concourse/concourse](https://github.com/concourse/concourse): 51 open pull requests at the time of testing. Cost 2.
 - [torvalds/linux](https://github.com/torvalds/linux): 305 open pull requests. Cost 8.
-- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes): 1072 open pull requests, and heavy use of leables. Cost: 22.
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes): 1072 open pull requests. Cost: 22.
 
 For the other two operations the costing is a bit easier:
 - `get`: Fixed cost of 1. Fetches the pull request at the given commit.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `disable_ci_skip`           | No       | `true`                           | Disable ability to skip builds with `[ci skip]` and `[skip ci]` in commit message or pull request title.                                                                                                                                                                                   |
 | `skip_ssl_verification`     | No       | `true`                           | Disable SSL/TLS certificate validation on git and API clients. Use with care!                                                                                                                                                                                                              |
 | `disable_forks`             | No       | `true`                           | Disable triggering of the resource if the pull request's fork repository is different to the configured repository.                                                                                                                                                                        |
-| `required_review_approvals` | No       | `2`                              | Disable triggering of the resource if the pull request does not have at least `X` approved review(s).                                                                                                                                                                                      | 
+| `required_review_approvals` | No       | `2`                              | Disable triggering of the resource if the pull request does not have at least `X` approved review(s).                                                                                                                                                                                      |
 | `git_crypt_key`             | No       | `AEdJVENSWVBUS0VZAAAAA...`       | Base64 encoded git-crypt key. Setting this will unlock / decrypt the repository with git-crypt. To get the key simply execute `git-crypt export-key -- - | base64` in an encrypted repository.                                                                                             |
 | `base_branch`               | No       | `master`                         | Name of a branch. The pipeline will only trigger on pull requests against the specified branch.                                                                                                                                                                                            |
 | `labels`                    | No       | `["bug", "enhancement"]`         | The labels on the PR. The pipeline will only trigger on pull requests having at least one of the specified labels.                                                                                                                                                                         |
@@ -63,12 +63,12 @@ generate notifications over the webhook. So if you have a repository with little
 
 #### `get`
 
-| Parameter             | Required | Example  | Description                                                                        |
-|-----------------------|----------|----------|------------------------------------------------------------------------------------|
-| `skip_download`       | No       | `true`   | Use with `get_params` in a `put` step to do nothing on the implicit get.           |
-| `integration_tool`    | No       | `rebase` | The integration tool to use, `merge`, `rebase` or `checkout`. Defaults to `merge`. |
-| `git_depth`           | No       | `1`      | Shallow clone the repository using the `--depth` Git option                        |
-| `list_changed_files`  | No       | `true`   | Generate a list of changed files and save alongside metadata                       |
+| Parameter            | Required | Example  | Description                                                                        |
+|----------------------|----------|----------|------------------------------------------------------------------------------------|
+| `skip_download`      | No       | `true`   | Use with `get_params` in a `put` step to do nothing on the implicit get.           |
+| `integration_tool`   | No       | `rebase` | The integration tool to use, `merge`, `rebase` or `checkout`. Defaults to `merge`. |
+| `git_depth`          | No       | `1`      | Shallow clone the repository using the `--depth` Git option                        |
+| `list_changed_files` | No       | `true`   | Generate a list of changed files and save alongside metadata                       |
 
 Clones the base (e.g. `master` branch) at the latest commit, and merges the pull request at the specified commit
 into master. This ensures that we are both testing and setting status on the exact commit that was requested in
@@ -106,18 +106,18 @@ empty commit to the PR*.
 
 #### `put`
 
-| Parameter      | Required | Example                             | Description                                                                                                       |
-|----------------|----------|-------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| `path`              | Yes      | `pull-request`                      | The name given to the resource in a GET step.                                                                     |
-| `status`            | No       | `SUCCESS`                           | Set a status on a commit. One of `SUCCESS`, `PENDING`, `FAILURE` and `ERROR`.                                     |
-| `base_context`      | No       | `concourse-ci`                      | Base context (prefix) used for the status context. Defaults to `concourse-ci`.                                    |
-| `context`           | No       | `unit-test`                         | A context to use for the status, which is prefixed by `base_context`. Defaults to `status`.                       |
-| `comment`           | No       | `hello world!`                      | A comment to add to the pull request.                                                                             |
-| `comment_file`      | No       | `my-output/comment.txt`             | Path to file containing a comment to add to the pull request (e.g. output of `terraform plan`).                   |
-| `target_url`        | No       | `$ATC_EXTERNAL_URL/builds/$BUILD_ID` | The target URL for the status, where users are sent when clicking details (defaults to the Concourse build page). |
-| `description`       | No       | `Concourse CI build failed`         | The description status on the specified pull request.                                                             |
-| `description_file`  | No       | `my-output/description.txt`         | Path to file containing the description status to add to the pull request                                         |
-| `delete_previous_comments` | No       | `true`         |  Boolean. Previous comments made on the pull request by this resource will be deleted before making the new comment. Useful for removing outdated information. |
+| Parameter                  | Required | Example                              | Description                                                                                                                                                   |
+|----------------------------|----------|--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `path`                     | Yes      | `pull-request`                       | The name given to the resource in a GET step.                                                                                                                 |
+| `status`                   | No       | `SUCCESS`                            | Set a status on a commit. One of `SUCCESS`, `PENDING`, `FAILURE` and `ERROR`.                                                                                 |
+| `base_context`             | No       | `concourse-ci`                       | Base context (prefix) used for the status context. Defaults to `concourse-ci`.                                                                                |
+| `context`                  | No       | `unit-test`                          | A context to use for the status, which is prefixed by `base_context`. Defaults to `status`.                                                                   |
+| `comment`                  | No       | `hello world!`                       | A comment to add to the pull request.                                                                                                                         |
+| `comment_file`             | No       | `my-output/comment.txt`              | Path to file containing a comment to add to the pull request (e.g. output of `terraform plan`).                                                               |
+| `target_url`               | No       | `$ATC_EXTERNAL_URL/builds/$BUILD_ID` | The target URL for the status, where users are sent when clicking details (defaults to the Concourse build page).                                             |
+| `description`              | No       | `Concourse CI build failed`          | The description status on the specified pull request.                                                                                                         |
+| `description_file`         | No       | `my-output/description.txt`          | Path to file containing the description status to add to the pull request                                                                                     |
+| `delete_previous_comments` | No       | `true`                               | Boolean. Previous comments made on the pull request by this resource will be deleted before making the new comment. Useful for removing outdated information. |
 
 Note that `comment`, `comment_file` and `target_url` will all expand environment variables, so in the examples above `$ATC_EXTERNAL_URL` will be replaced by the public URL of the Concourse ATCs.
 See https://concourse-ci.org/implementing-resource-types.html#resource-metadata for more details about metadata that is available via environment variables.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Ref the above, this resource will incur the following (estimated) costs:
 
 E.g., typical use for a repository with 125 open pull requests, with on average 3 labels per PR will incur the following costs for every commit:
 
-- `check`: List PRs: 2, Latest commit: 125, Lables: 125x3=375. Total: 5.
+- `check`: List PRs: 2, Latest commit: 125, Lables: 125x3=375. The total cost is then (2+125+375)/100=5.
 - `in`: 1 (fetch the pull request at the given commit ref)
 - `out`: 1 (set status on the commit)
 

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ Ref the above, this resource will incur the following (estimated) costs:
 - `check`:
   - List the last 100 (open) PRs: 100
   - Get the last commit from the 100 PRs: 100
-  - Get the first 100 labels from each PR: 100x100 = 1000
-  - Total: 1200/100 = 12. This is the _max_ if you have 100 open PRs and 100 labels on each PR.
+  - Get the first 100 labels from each PR: 100x100 = 10000
+  - Total: 10200/100 = 102. This is the _max_ if you have 100 open PRs and 100 labels on each PR.
 - `get`: Fixed cost of 1. Fetches the pull request at the given commit.
 - `put`: Uses the V3 API and has a min cost of 1, +1 for each of `status`, `comment` and `comment_file` etc.
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -218,8 +218,7 @@ func TestCheckAPICostE2E(t *testing.T) {
 			_, err = resource.Check(input, githubClient)
 			require.NoError(t, err)
 
-			// +1 since that is the cost of fetching the remaining rate limit
-			cost := before - getRemainingRateLimit(t, githubClient.V4) + 1
+			cost := before - getRemainingRateLimit(t, githubClient.V4)
 			assert.True(t, tc.ceiling >= cost, "cost (%d) exceeds ceiling (%d)", cost, tc.ceiling)
 		})
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -220,7 +220,7 @@ func TestCheckAPICostE2E(t *testing.T) {
 
 			// +1 since that is the cost of fetching the remaining rate limit
 			cost := before - getRemainingRateLimit(t, githubClient.V4) + 1
-			assert.True(t, tc.ceiling >= cost, "cost (%d) exceeds ceiling (%d)", cost, before)
+			assert.True(t, tc.ceiling >= cost, "cost (%d) exceeds ceiling (%d)", cost, tc.ceiling)
 		})
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -472,7 +472,7 @@ func TestGetAndPutE2E(t *testing.T) {
 }
 
 func TestPutCommentsE2E(t *testing.T) {
-	owner := "rcoy-v"
+	owner := "itsdalmo"
 	repo := "github-pr-resource-e2e"
 
 	tests := []struct {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -202,8 +202,8 @@ func TestCheckAPICostE2E(t *testing.T) {
 				Repository:  "itsdalmo/test-repository",
 				AccessToken: os.Getenv("GITHUB_ACCESS_TOKEN"),
 			},
-			version: resource.Version{PR: targetPullRequestID, Commit: targetCommitID, CommittedDate: targetDateTime},
-			ceiling: 1,
+			version: resource.Version{},
+			ceiling: 2,
 		},
 	}
 
@@ -219,7 +219,7 @@ func TestCheckAPICostE2E(t *testing.T) {
 			require.NoError(t, err)
 
 			cost := before - getRemainingRateLimit(t, githubClient.V4)
-			assert.True(t, tc.ceiling >= cost, "cost (%d) exceeds ceiling (%d)", cost, tc.ceiling)
+			assert.Equal(t, tc.ceiling, cost, "cost against ratelimit is fixed")
 		})
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -194,16 +194,16 @@ func TestCheckAPICostE2E(t *testing.T) {
 		description string
 		source      resource.Source
 		version     resource.Version
-		ceiling     int
+		expected    int
 	}{
 		{
-			description: "cost does not exceed the defined ceiling",
+			description: "check has a known cost against ratelimit",
 			source: resource.Source{
 				Repository:  "itsdalmo/test-repository",
 				AccessToken: os.Getenv("GITHUB_ACCESS_TOKEN"),
 			},
-			version: resource.Version{},
-			ceiling: 2,
+			version:  resource.Version{},
+			expected: 2,
 		},
 	}
 
@@ -219,7 +219,7 @@ func TestCheckAPICostE2E(t *testing.T) {
 			require.NoError(t, err)
 
 			cost := before - getRemainingRateLimit(t, githubClient.V4)
-			assert.Equal(t, tc.ceiling, cost, "cost against ratelimit is fixed")
+			assert.Equal(t, tc.expected, cost, "unexpected cost for check")
 		})
 	}
 }


### PR DESCRIPTION
Ref #156 - this PR updates the documentation on costs, and adds a E2E test to keep track of the cost of `check` against the Github rate limit. Cost calculation needs to be verified.