### PR TITLE
Bump go version to 1.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ build/*
 # Taskfile
 .task
 
+# Task installation in Travis
+bin/task
+
 # Editor
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 matrix:
   include:
   - os: osx
-    go: 1.12.x
+    go: 1.13.x
   - os: linux
-    go: 1.12.x
+    go: 1.13.x
 notifications:
   email: false
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ matrix:
 notifications:
   email: false
 script:
-- go get -u -v github.com/go-task/task/cmd/task && task ci
+- curl -sL https://taskfile.dev/install.sh | sh
+- ./bin/task ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.13 as builder
 ADD . /go/src/github.com/telia-oss/github-pr-resource
 WORKDIR /go/src/github.com/telia-oss/github-pr-resource
-RUN go get -u -v github.com/go-task/task/cmd/task && task build
+RUN curl -sL https://taskfile.dev/install.sh | sh
+RUN ./bin/task build
 
 FROM alpine:3.8 as resource
 COPY --from=builder /go/src/github.com/telia-oss/github-pr-resource/build /opt/resource

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as builder
+FROM golang:1.13 as builder
 ADD . /go/src/github.com/telia-oss/github-pr-resource
 WORKDIR /go/src/github.com/telia-oss/github-pr-resource
 RUN go get -u -v github.com/go-task/task/cmd/task && task build

--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require (
 	golang.org/x/oauth2 v0.0.0-20181031022657-8527f56f7107
 	google.golang.org/appengine v1.2.0 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Need to stay on top of updates. Starting with Go, then our dependencies.