### PR TITLE
fix: ensure insteadOf gets picked up for submodules

### DIFF
--- a/git.go
+++ b/git.go
@@ -71,10 +71,10 @@ func (g *GitClient) Init(branch string) error {
 	if err := g.command("git", "config", "user.email", "concourse@local").Run(); err != nil {
 		return fmt.Errorf("failed to configure git email: %s", err)
 	}
-	if err := g.command("git", "config", "url.https://x-oauth-basic@github.com/.insteadOf", "git@github.com:").Run(); err != nil {
+	if err := g.command("git", "config", "--global", "url.https://x-oauth-basic@github.com/.insteadOf", "git@github.com:").Run(); err != nil {
 		return fmt.Errorf("failed to configure github url: %s", err)
 	}
-	if err := g.command("git", "config", "url.https://.insteadOf", "git://").Run(); err != nil {
+	if err := g.command("git", "config", "--global", "url.https://.insteadOf", "git://").Run(); err != nil {
 		return fmt.Errorf("failed to configure github url: %s", err)
 	}
 	return nil


### PR DESCRIPTION
Hi @itsdalmo. I know you just changed this for the `e2e` test, but I'm opening it back up for feedback.

We have some private repos that must use git instead of https. Unless the `git config` is applied globally, I have found that I am unable to get the `insteadOf` directive to work on the submodules. I've tried a number of variations on it, including setting `GIT_CONFIG` and supplying a file identical to the global config. Unfortunately, that doesn't supplement the `.git/config`, but rather simply overrides it.

I'm wondering if you or anyone else may have suggestions on how to fix? Do the e2e tests break, or does it just leave your local test environment in a bad state?