### PR TITLE
New metadata file that supports the new 'load_var' Concourse statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,15 @@ input. Because the base of the PR is not locked to a specific commit in versions
 requested version and the metadata emitted by `get` are available to your tasks as JSON:
 - `.git/resource/version.json`
 - `.git/resource/metadata.json`
+- `.git/resource/metadata-map.json`
 - `.git/resource/changed_files` (if enabled by `list_changed_files`)
+
+The `metadata.json` file contains an array of objects, one for each key-value
+pair, with a `name` key and a `value` key. In order to support the
+[`load_var` step][load_var_step], another `metadata-map.json` provides the
+same informtion with a plain key-value format.
+
+[load_var_step]: https://concourse-ci.org/load-var-step.html
 
 The information in `metadata.json` is also available as individual files in the `.git/resource` directory, e.g. the `base_sha`
 is available as `.git/resource/base_sha`. For a complete list of available (individual) metadata files, please check the code

--- a/in.go
+++ b/in.go
@@ -81,6 +81,17 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 		}
 	}
 
+	metadataMap := make(map[string]string)
+	for _, d := range metadata {
+		metadataMap[d.Name] = d.Value
+	}
+	if b, err = json.Marshal(metadataMap); err != nil {
+		return nil, fmt.Errorf("failed to marshal map of metadata: %s", err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(path, "metadata-map.json"), b, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write metadata map file: %s", err)
+	}
+
 	switch tool := request.Params.IntegrationTool; tool {
 	case "rebase":
 		if err := git.Rebase(pull.BaseRefName, pull.Tip.OID, request.Params.Submodules); err != nil {

--- a/in_test.go
+++ b/in_test.go
@@ -18,15 +18,16 @@ import (
 func TestGet(t *testing.T) {
 
 	tests := []struct {
-		description    string
-		source         resource.Source
-		version        resource.Version
-		parameters     resource.GetParameters
-		pullRequest    *resource.PullRequest
-		versionString  string
-		metadataString string
-		files          []resource.ChangedFileObject
-		filesString    string
+		description       string
+		source            resource.Source
+		version           resource.Version
+		parameters        resource.GetParameters
+		pullRequest       *resource.PullRequest
+		versionString     string
+		metadataString    string
+		metadataMapString string
+		files             []resource.ChangedFileObject
+		filesString       string
 	}{
 		{
 			description: "get works",
@@ -41,10 +42,11 @@ func TestGet(t *testing.T) {
 				ApprovedReviewCount: "0",
 				State:               githubv4.PullRequestStateOpen,
 			},
-			parameters:     resource.GetParameters{},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
-			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			parameters:        resource.GetParameters{},
+			pullRequest:       createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
+			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
 		},
 		{
 			description: "get supports unlocking with git crypt",
@@ -60,10 +62,11 @@ func TestGet(t *testing.T) {
 				ApprovedReviewCount: "0",
 				State:               githubv4.PullRequestStateOpen,
 			},
-			parameters:     resource.GetParameters{},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
-			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			parameters:        resource.GetParameters{},
+			pullRequest:       createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
+			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
 		},
 		{
 			description: "get supports rebasing",
@@ -81,9 +84,10 @@ func TestGet(t *testing.T) {
 			parameters: resource.GetParameters{
 				IntegrationTool: "rebase",
 			},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
-			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			pullRequest:       createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
+			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
 		},
 		{
 			description: "get supports checkout",
@@ -101,9 +105,10 @@ func TestGet(t *testing.T) {
 			parameters: resource.GetParameters{
 				IntegrationTool: "checkout",
 			},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
-			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			pullRequest:       createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
+			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
 		},
 		{
 			description: "get supports git_depth",
@@ -121,9 +126,10 @@ func TestGet(t *testing.T) {
 			parameters: resource.GetParameters{
 				GitDepth: 2,
 			},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
-			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			pullRequest:       createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
+			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
 		},
 		{
 			description: "get supports list_changed_files",
@@ -150,9 +156,10 @@ func TestGet(t *testing.T) {
 					Path: "Other.md",
 				},
 			},
-			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
-			filesString:    "README.md\nOther.md\n",
+			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
+			filesString:       "README.md\nOther.md\n",
 		},
 	}
 
@@ -184,6 +191,9 @@ func TestGet(t *testing.T) {
 
 				metadata := readTestFile(t, filepath.Join(dir, ".git", "resource", "metadata.json"))
 				assert.Equal(t, tc.metadataString, metadata)
+
+				metadataMap := readTestFile(t, filepath.Join(dir, ".git", "resource", "metadata-map.json"))
+				assert.Equal(t, tc.metadataMapString, metadataMap)
 
 				// Verify individual files
 				files := map[string]string{


### PR DESCRIPTION
Hi there,
This PR is meant to provide a solution to the issue #248.
Here I've added a new `metadata-map.json` in `.git/resource` directory. This file contains the same information as the legacy `metadata.json`, but properly organised in a key-value format. Such JSON file can be loaded directly in the pipeline variables context using the new `load_var` step. See https://concourse-ci.org/load-var-step.html for more information.
I've updated tests, they are running fine, and I've documented the new feature.
Don't hesitate to provide feedback so that we can move on quickly.
Best,
Benjamin